### PR TITLE
Backward compatibility with BP Docs (and potentially other plugins) checking BuddyPress URI globals before `bp_parse_query`

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -414,7 +414,7 @@ function disable_buddypress_legacy_url_parser() {
 	 *
 	 * @see `bp_nav_menu_get_loggedin_pages()`
 	 */
-	if ( apply_filters( 'wp_using_themes', defined( 'WP_USE_THEMES' ) && WP_USE_THEMES ) ) {
+	if ( apply_filters( 'wp_using_themes', defined( 'WP_USE_THEMES' ) && WP_USE_THEMES ) || wp_doing_ajax() ) {
 		remove_action( 'bp_init', 'bp_setup_nav', 6 );
 		add_action( 'bp_parse_query', 'bp_setup_nav', 12 );
 	}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -381,6 +381,23 @@ function bp_core_register_post_types() {
 add_action( 'bp_core_register_post_types', __NAMESPACE__ . '\bp_core_register_post_types' );
 
 /**
+ * Checks if the displayed page is the WP Login one.
+ *
+ * @since 1.0.0
+ */
+function is_login_page() {
+	$is_login = false;
+
+	if ( isset( $GLOBALS['pagenow'] ) && ( false !== strpos( $GLOBALS['pagenow'], 'wp-login.php' ) ) ) {
+		$is_login = true;
+	} elseif ( isset( $_SERVER['SCRIPT_NAME'] ) && false !== strpos( $_SERVER['SCRIPT_NAME'], 'wp-login.php' ) ) { // phpcs:ignore
+		$is_login = true;
+	}
+
+	return $is_login;
+}
+
+/**
  * Neutralize the BuddyPress Legacy URL parser.
  *
  * @since 1.0.0
@@ -414,7 +431,7 @@ function disable_buddypress_legacy_url_parser() {
 	 *
 	 * @see `bp_nav_menu_get_loggedin_pages()`
 	 */
-	if ( apply_filters( 'wp_using_themes', defined( 'WP_USE_THEMES' ) && WP_USE_THEMES ) || wp_doing_ajax() ) {
+	if ( apply_filters( 'wp_using_themes', defined( 'WP_USE_THEMES' ) && WP_USE_THEMES ) || wp_doing_ajax() || is_login_page() ) {
 		remove_action( 'bp_init', 'bp_setup_nav', 6 );
 		add_action( 'bp_parse_query', 'bp_setup_nav', 12 );
 	}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -391,10 +391,20 @@ function disable_buddypress_legacy_url_parser() {
 	// Stop hooking `bp_init` to setup the canonical stack & BP document title.
 	remove_action( 'bp_init', 'bp_setup_canonical_stack', 5 );
 	remove_action( 'bp_init', 'bp_setup_title', 8 );
+	remove_action( 'bp_init', '_bp_maybe_remove_redirect_canonical' );
+	remove_action( 'bp_init', 'bp_remove_adjacent_posts_rel_link' );
+
+	/*
+	 * @todo raise the priority of the action hooked to `bp_parse_query` in
+	 * `\BP_Component::setup_actions()`.
+	 * Then raise the following priorities accordingly and before `10`.
+	 */
 
 	// Start hooking `bp_parse_query` to setup the canonical stack & BP document title.
 	add_action( 'bp_parse_query', 'bp_setup_canonical_stack', 11 );
 	add_action( 'bp_parse_query', 'bp_setup_title', 14 );
+	add_action( 'bp_parse_query', '_bp_maybe_remove_redirect_canonical', 20 );
+	add_action( 'bp_parse_query', 'bp_remove_adjacent_posts_rel_link', 20 );
 
 	/**
 	 * On front-end, hook to `bp_parse_query` instead of `bp_init` to set up the navigation.

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -407,6 +407,7 @@ function disable_buddypress_legacy_url_parser() {
 
 	// Stop hooking `bp_init` to setup the canonical stack & BP document title.
 	remove_action( 'bp_init', 'bp_setup_canonical_stack', 5 );
+	remove_action( 'bp_init', 'bp_core_action_search_site', 7 );
 	remove_action( 'bp_init', 'bp_setup_title', 8 );
 	remove_action( 'bp_init', '_bp_maybe_remove_redirect_canonical' );
 	remove_action( 'bp_init', 'bp_remove_adjacent_posts_rel_link' );
@@ -419,6 +420,7 @@ function disable_buddypress_legacy_url_parser() {
 
 	// Start hooking `bp_parse_query` to setup the canonical stack & BP document title.
 	add_action( 'bp_parse_query', 'bp_setup_canonical_stack', 11 );
+	add_action( 'bp_parse_query', 'bp_core_action_search_site', 13 );
 	add_action( 'bp_parse_query', 'bp_setup_title', 14 );
 	add_action( 'bp_parse_query', '_bp_maybe_remove_redirect_canonical', 20 );
 	add_action( 'bp_parse_query', 'bp_remove_adjacent_posts_rel_link', 20 );

--- a/inc/globals.php
+++ b/inc/globals.php
@@ -30,7 +30,16 @@ function globals() {
 	// URL.
 	$plugin_url      = plugins_url( dirname( __FILE__ ) );
 	$bpr->url        = $plugin_url;
-	$bpr->backcompat = new \stdClass();
+	$bpr->backcompat = array(
+		'current_component'      => null, // The BP Component, except for the Members one when a user is displayed.
+		'current_item'           => null, // Only used for the Groups single item.
+		'current_action'         => null,
+		'action_variables'       => null,
+		'displayed_user'         => null, // Only used for the Members single item.
+		'current_member_type'    => null, // Only used for the Members component.
+		'current_group'          => null, // Only used for the Groups single item.
+		'current_directory_type' => null, // Only used for the Groups component.
+	);
 
 	/**
 	 * Private (do not use) hook used to include files early.

--- a/inc/globals.php
+++ b/inc/globals.php
@@ -28,8 +28,9 @@ function globals() {
 	$bpr->dir   = $plugin_dir;
 
 	// URL.
-	$plugin_url = plugins_url( dirname( __FILE__ ) );
-	$bpr->url   = $plugin_url;
+	$plugin_url      = plugins_url( dirname( __FILE__ ) );
+	$bpr->url        = $plugin_url;
+	$bpr->backcompat = new \stdClass();
 
 	/**
 	 * Private (do not use) hook used to include files early.

--- a/inc/loader.php
+++ b/inc/loader.php
@@ -97,6 +97,7 @@ function includes( $plugin_dir = '' ) {
 	if ( bp_is_active( 'xprofile' ) ) {
 		require $path . 'src/bp-xprofile/bp-xprofile-rewrites.php';
 		require $path . 'src/bp-xprofile/bp-xprofile-template.php';
+		require $path . 'src/bp-xprofile/bp-xprofile-functions.php';
 	}
 
 	$template_pack_dir = sprintf( $path . 'src/bp-templates/bp-%s.php', bp_get_theme_package_id() );

--- a/inc/loader.php
+++ b/inc/loader.php
@@ -69,6 +69,7 @@ function includes( $plugin_dir = '' ) {
 		require $path . 'src/bp-groups/bp-groups-template.php';
 		require $path . 'src/bp-groups/bp-groups-rewrites.php';
 		require $path . 'src/bp-groups/bp-groups-functions.php';
+		require $path . 'src/bp-groups/bp-groups-filters.php';
 
 		if ( bp_is_active( 'notifications' ) ) {
 			require $path . 'src/bp-groups/bp-groups-notifications.php';

--- a/inc/loader.php
+++ b/inc/loader.php
@@ -25,6 +25,7 @@ function includes( $plugin_dir = '' ) {
 
 	// Core is always required.
 	require $path . 'src/bp-core/bp-core-template-loader.php';
+	require $path . 'src/bp-core/bp-core-template.php';
 	require $path . 'src/bp-core/bp-core-rewrites.php';
 	require $path . 'src/bp-core/bp-core-catchuri.php';
 	require $path . 'src/bp-core/bp-core-functions.php';

--- a/src/bp-activity/bp-activity-rewrites.php
+++ b/src/bp-activity/bp-activity-rewrites.php
@@ -229,7 +229,7 @@ function bp_activity_rewrites_get_sitewide_feed_url() {
  */
 function bp_activity_rewrites_get_member_rss_url( $user_id = 0 ) {
 	if ( ! $user_id ) {
-		$user_id = bp_displayed_user_id();
+		$user_id = \bp_displayed_user_id();
 	}
 
 	$slug       = bp_get_activity_slug();

--- a/src/bp-activity/bp-activity-rewrites.php
+++ b/src/bp-activity/bp-activity-rewrites.php
@@ -250,10 +250,10 @@ function bp_activity_rewrites_get_member_rss_url( $user_id = 0 ) {
 		} elseif ( bp_is_user_groups_activity() ) {
 			$url_params['single_item_action'] = bp_get_groups_slug();
 
-		} elseif ( 'favorites' === bp_current_action() ) {
+		} elseif ( 'favorites' === \bp_current_action() ) {
 			$url_params['single_item_action'] = 'favorites';
 
-		} elseif ( 'mentions' === bp_current_action() && bp_activity_do_mentions() ) {
+		} elseif ( 'mentions' === \bp_current_action() && bp_activity_do_mentions() ) {
 			$url_params['single_item_action'] = 'mentions';
 
 		} else {

--- a/src/bp-activity/classes/class-activity-component.php
+++ b/src/bp-activity/classes/class-activity-component.php
@@ -31,7 +31,7 @@ class Activity_Component extends \BP_Activity_Component {
 	public function late_includes() {
 		parent::late_includes();
 
-		if ( bp_is_current_component( 'activity' ) ) {
+		if ( \bp_is_current_component( 'activity' ) ) {
 			// Set includes directory.
 			$inc_dir = trailingslashit( bp_rewrites()->dir ) . 'src/bp-activity/';
 

--- a/src/bp-activity/classes/class-activity-component.php
+++ b/src/bp-activity/classes/class-activity-component.php
@@ -36,7 +36,7 @@ class Activity_Component extends \BP_Activity_Component {
 			$inc_dir = trailingslashit( bp_rewrites()->dir ) . 'src/bp-activity/';
 
 			// Screens - Single permalink.
-			if ( bp_is_current_action( 'p' ) || is_numeric( bp_current_action() ) ) {
+			if ( bp_is_current_action( 'p' ) || is_numeric( \bp_current_action() ) ) {
 				require $inc_dir . 'screens/permalink.php';
 			}
 		}

--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -188,12 +188,13 @@ function bp_core_get_from_uri( $bp_global = array() ) {
 					// Let's take care of the Groups component.
 				} elseif ( 'groups' === $component_id && bp_is_active( 'groups' ) ) {
 					// The backcompat global is not set yet. Let's make it true temporarly!
-					add_filter( 'bp_is_current_component', '__return_true' );
+					$restore_current_component = $bp->current_component;
+					$bp->current_component     = 'groups';
 
 					$current_group = $bp->groups->set_current_group( $backcompat['current_action'], true );
 
-					// Remove this temporary filter.
-					remove_filter( 'bp_is_current_component', '__return_true' );
+					// Restore the BP global.
+					$bp->current_component = $restore_current_component;
 
 					if ( isset( $current_group->id ) && $current_group->id ) {
 						$backcompat['current_item']  = $backcompat['current_action'];

--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -289,6 +289,10 @@ function bp_core_get_from_uri( $bp_global = array() ) {
 		bp_rewrites()->backcompat = $backcompat;
 	}
 
+	if ( ! isset( $backcompat[ $main_key ] ) ) {
+		return false;
+	}
+
 	// Most of the BuddyPress globals.
 	$retval = $backcompat[ $main_key ];
 

--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -28,3 +28,279 @@ function bp_core_load_template() {
 }
 add_action( 'bp_core_pre_load_template', __NAMESPACE__ . '\bp_core_load_template' );
 add_action( 'bp_setup_theme_compat', __NAMESPACE__ . '\bp_core_load_template' );
+
+/**
+ * Get a specific BuddyPress URI segment based on the current URI.
+ *
+ * You shouldn't really have to use this function unless you need to find a BP
+ * URI segment earlier than the `'bp_parse_query'` action.
+ *
+ * @since ?.0.0
+ *
+ * @param array $bp_global An array containing the BuddyPress global name. Required.
+ * @return mixed|false The global value if found. False otherwise.
+ */
+function bp_core_get_from_uri( $bp_global = array() ) {
+	// Don't do this on non-root blogs unless multiblog mode is on.
+	if ( ! bp_is_root_blog() && ! bp_is_multiblog_mode() ) {
+		return false;
+	}
+
+	$bp         = buddypress();
+	$backcompat = bp_rewrites()->backcompat;
+
+	if ( ! is_array( $bp_global ) ) {
+		$bp_global = array( $bp_global );
+	}
+
+	$main_key = array_shift( $bp_global );
+
+	// Get existing BuddyPress URI if already calculated.
+	if ( isset( $bp->unfiltered_uri ) && $bp->unfiltered_uri ) {
+		$bp_uri = $bp->unfiltered_uri;
+
+		// calculate the BuddyPress URI.
+	} elseif ( isset( $_SERVER['REQUEST_URI'] ) ) {
+		$requested_uri = esc_url( wp_unslash( $_SERVER['REQUEST_URI'] ) ); // phpcs:ignore
+
+		/**
+		 * Filters the BuddyPress global URI path.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $path Path to set.
+		 */
+		$path = apply_filters( 'bp_uri', $requested_uri );
+
+		// Get the regular site path.
+		$site_path = trim( bp_core_get_site_path(), '/' );
+
+		// Get the multisite subdirectory install site path.
+		if ( is_multisite() && ! is_subdomain_install() ) {
+			$current_blog = get_site();
+			$site_path    = trim( $current_blog->path, '/' );
+		}
+
+		// strip site path from URI.
+		$path   = str_replace( $site_path, '', $path );
+		$bp_uri = explode( '/', trim( wp_parse_url( $path, PHP_URL_PATH ), '/' ) );
+
+		if ( 'unfiltered_uri' === $main_key ) {
+			return $bp_uri;
+		}
+
+		// save for later.
+		$bp->unfiltered_uri = $bp_uri;
+	} else {
+		return false;
+	}
+
+	if ( ! isset( $backcompat[ $main_key ] ) || is_null( $backcompat[ $main_key ] ) ) {
+		if ( ! isset( $bp->pages ) || ! $bp->pages ) {
+			$bp->pages = bp_core_get_directory_pages();
+		}
+
+		foreach ( $bp->pages as $component_id => $component ) {
+			$bp_component_index = array_search( $component->slug, $bp_uri, true );
+
+			if ( 0 === $bp_component_index ) {
+				$backcompat['current_component'] = $component_id;
+				array_shift( $bp_uri );
+
+				if ( ! $bp_uri ) {
+					break;
+				}
+
+				$backcompat['current_action'] = reset( $bp_uri );
+
+				// Let's take care of the Members component.
+				if ( 'members' === $component_id ) {
+					// Reset the current component.
+					$backcompat['current_component'] = false;
+
+					// Try to get a potiential member.
+					$member_data = bp_rewrites_get_member_data();
+					$member      = get_user_by( $member_data['field'], $backcompat['current_action'] );
+
+					if ( $member instanceof \WP_User ) {
+						// Reset the current action.
+						$backcompat['current_action'] = '';
+
+						// Set the displayed user.
+						$backcompat['displayed_user'] = (object) array(
+							'id'       => $member->ID,
+							'userdata' => bp_core_get_core_userdata( $member->ID ),
+							'fullname' => $member->display_name,
+							'domain'   => bp_member_rewrites_get_url( $member->ID, bp_core_get_username( $member->ID ) ),
+						);
+
+						// Check if the user has a custom front.
+						$backcompat['displayed_user']->front_template = bp_displayed_user_get_front_template( $backcompat['displayed_user'] );
+
+						array_shift( $bp_uri );
+
+						if ( ! $bp_uri ) {
+							if ( $backcompat['displayed_user']->front_template ) {
+								$backcompat['current_component'] = 'front';
+							} elseif ( bp_is_active( 'activity' ) ) {
+								$backcompat['current_component'] = $bp->activity->id;
+							} else {
+								$backcompat['current_component'] = ( 'xprofile' === $bp->profile->id ) ? 'profile' : $bp->profile->id;
+							}
+						} else {
+							$member_component_slug       = reset( $bp_uri );
+							$member_component_rewrite_id = bp_rewrites_get_custom_slug_rewrite_id( 'members', $member_component_slug );
+							if ( $member_component_rewrite_id ) {
+								$member_component_slug = str_replace( 'bp_member_', '', $member_component_rewrite_id );
+							}
+
+							$backcompat['current_component'] = $member_component_slug;
+							array_shift( $bp_uri );
+
+							if ( $bp_uri ) {
+								$backcompat['current_action'] = reset( $bp_uri );
+								array_shift( $bp_uri );
+
+								// All the rest is action variables.
+								$backcompat['action_variables'] = $bp_uri;
+							}
+						}
+					} else {
+						array_shift( $bp_uri );
+
+						if ( $bp_uri && bp_get_members_member_type_base() === $backcompat['current_action'] ) {
+							$member_type_slug = reset( $bp_uri );
+
+							$member_type = bp_get_member_types(
+								array(
+									'has_directory'  => true,
+									'directory_slug' => $member_type_slug,
+								)
+							);
+
+							if ( $member_type ) {
+								$backcompat['current_action']      = '';
+								$backcompat['current_member_type'] = reset( $member_type );
+							}
+						}
+					}
+
+					// Let's take care of the Groups component.
+				} elseif ( 'groups' === $component_id && bp_is_active( 'groups' ) ) {
+					// The backcompat global is not set yet. Let's make it true temporarly!
+					add_filter( 'bp_is_current_component', '__return_true' );
+
+					$current_group = $bp->groups->set_current_group( $backcompat['current_action'], true );
+
+					// Remove this temporary filter.
+					remove_filter( 'bp_is_current_component', '__return_true' );
+
+					if ( isset( $current_group->id ) && $current_group->id ) {
+						$backcompat['current_item']  = $backcompat['current_action'];
+						$backcompat['current_group'] = $current_group;
+
+						// Remove the current Group's slug.
+						array_shift( $bp_uri );
+
+						if ( ! $bp_uri ) {
+							$backcompat['current_action'] = '';
+						} else {
+							$context        = 'bp_group_read_';
+							$current_action = array_shift( $bp_uri );
+
+							// Get the rewrite ID corresponfing to the custom slug.
+							$current_action_rewrite_id = bp_rewrites_get_custom_slug_rewrite_id( 'groups', $current_action, $context );
+							if ( $current_action_rewrite_id ) {
+								$current_action = str_replace( $context, '', $current_action_rewrite_id );
+								$current_action = str_replace( '_', '-', $current_action );
+							}
+
+							$backcompat['current_action'] = $current_action;
+							$action_variables             = $bp_uri;
+
+							if ( $action_variables ) {
+								// In the Manage context, we need to translate custom slugs to BP Expected variables.
+								if ( 'admin' === $current_action ) {
+									$context = 'bp_group_manage_';
+
+									// Get the rewrite ID corresponfing to the custom slug.
+									$first_action_variable_rewrite_id = bp_rewrites_get_custom_slug_rewrite_id( 'groups', $action_variables[0], $context );
+
+									if ( $first_action_variable_rewrite_id ) {
+										$first_action_variable = str_replace( $context, '', $first_action_variable_rewrite_id );
+
+										// Make sure the action is stored as a slug: underscores need to be replaced by dashes.
+										$action_variables[0] = str_replace( '_', '-', $first_action_variable );
+									}
+								}
+							}
+
+							$backcompat['action_variables'] = $action_variables;
+						}
+					} elseif ( isset( $bp_uri[1] ) && bp_get_groups_group_type_base() === $backcompat['current_action'] ) {
+						$group_type_slug = array_shift( $bp_uri );
+
+						$group_type = bp_groups_get_group_types(
+							array(
+								'has_directory'  => true,
+								'directory_slug' => $group_type_slug,
+							)
+						);
+
+						if ( $group_type ) {
+							$backcompat['current_directory_type'] = reset( $group_type );
+							$backcompat['action_variables']       = array( $group_type_slug );
+						}
+					} elseif ( bp_rewrites_get_slug( 'groups', 'bp_group_create', 'create' ) === $backcompat['current_action'] ) {
+						$backcompat['current_action'] = 'create';
+
+						array_shift( $bp_uri );
+						$action_variables = $bp_uri;
+
+						if ( isset( $action_variables[1] ) ) {
+							$context = 'bp_group_create_';
+
+							// Get the rewrite ID corresponfing to the custom slug.
+							$second_action_variable_rewrite_id = bp_rewrites_get_custom_slug_rewrite_id( 'groups', $action_variables[1], $context );
+							if ( $second_action_variable_rewrite_id ) {
+								$second_action_variable = str_replace( $context, '', $second_action_variable_rewrite_id );
+								$action_variables[0]    = 'step';
+								$action_variables[1]    = str_replace( '_', '-', $second_action_variable );
+							}
+						}
+
+						$backcompat['action_variables'] = $action_variables;
+					}
+				} else {
+					array_shift( $bp_uri );
+					$backcompat['action_variables'] = $bp_uri;
+				}
+			}
+		}
+
+		foreach ( $backcompat as $key_compat => $value_compat ) {
+			if ( ! is_null( $value_compat ) ) {
+				continue;
+			}
+
+			$backcompat[ $key_compat ] = false;
+		}
+
+		bp_rewrites()->backcompat = $backcompat;
+	}
+
+	// Most of the BuddyPress globals.
+	$retval = $backcompat[ $main_key ];
+
+	if ( $bp_global ) {
+		$sub_key = array_shift( $bp_global );
+		$retval  = false;
+
+		// e.g.: specific case of the displayed user ID.
+		if ( isset( $backcompat[ $main_key ]->{$sub_key} ) ) {
+			$retval = $backcompat[ $main_key ]->{$sub_key};
+		}
+	}
+
+	return $retval;
+}

--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -238,7 +238,7 @@ function bp_core_get_from_uri( $bp_global = array() ) {
 							$backcompat['action_variables'] = $action_variables;
 						}
 					} elseif ( isset( $bp_uri[1] ) && bp_get_groups_group_type_base() === $backcompat['current_action'] ) {
-						$group_type_slug = array_shift( $bp_uri );
+						$group_type_slug = array_pop( $bp_uri );
 
 						$group_type = bp_groups_get_group_types(
 							array(

--- a/src/bp-core/bp-core-rewrites.php
+++ b/src/bp-core/bp-core-rewrites.php
@@ -81,10 +81,10 @@ function bp_rewrites_get_member_slug( $user_id = 0 ) {
 		$prop = 'user_login';
 	}
 
-	if ( (int) bp_displayed_user_id() === (int) $user_id ) {
-		$slug = isset( $bp->displayed_user->userdata->{$prop} ) ? $bp->displayed_user->userdata->{$prop} : null;
-	} elseif ( (int) bp_loggedin_user_id() === (int) $user_id ) {
+	if ( (int) bp_loggedin_user_id() === (int) $user_id ) {
 		$slug = isset( $bp->loggedin_user->userdata->{$prop} ) ? $bp->loggedin_user->userdata->{$prop} : null;
+	} elseif ( (int) \bp_displayed_user_id() === (int) $user_id ) {
+		$slug = isset( $bp->displayed_user->userdata->{$prop} ) ? $bp->displayed_user->userdata->{$prop} : null;
 	} else {
 		$slug = bp_core_get_username( $user_id );
 	}

--- a/src/bp-core/bp-core-template-loader.php
+++ b/src/bp-core/bp-core-template-loader.php
@@ -23,7 +23,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param \WP_Query $posts_query WP_Query object.
  */
 function bp_parse_query( $posts_query ) {
-	$bp_is_doing_ajax = isset( buddypress()->ajax->WP );
+	$bp               = buddypress();
+	$bp_is_doing_ajax = isset( $bp->ajax->WP );
 
 	// Bail if $posts_query is not the main loop and not done in BP Ajax context.
 	if ( ! $bp_is_doing_ajax && ! $posts_query->is_main_query() ) {
@@ -39,6 +40,10 @@ function bp_parse_query( $posts_query ) {
 	if ( ! $bp_is_doing_ajax && is_admin() ) {
 		return;
 	}
+
+	// Some Legacy Parser URL globals/filters need to be set at this time.
+	$bp->unfiltered_uri        = bp_core_get_from_uri( array( 'unfiltered_uri' ) );
+	$bp->unfiltered_uri_offset = 0; // It's unclear how this is set for now. @todo review this.
 
 	/**
 	 * Fires at the end of the bp_parse_query function.

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -78,6 +78,26 @@ function bp_current_component( $current_component = false ) {
 add_filter( 'bp_current_component', __NAMESPACE__ . '\bp_current_component', 1, 1 );
 
 /**
+ * Adds backward compatibility when `\bp_is_current_component()` is called too early.
+ *
+ * NB: this would probably be unnecessary if `\bp_is_current_component()` was using `\bp_current_component()`.
+ *
+ * @since ?.0.0
+ *
+ * @param bool   $is_current_component True if the current component is the one being checked. False otherwise.
+ * @param string $component            The component ID to check.
+ * @return bool                        True if the current component is the one being checked. False otherwise.
+ */
+function bp_is_current_component( $is_current_component = false, $component = '' ) {
+	if ( ! $is_current_component && bp_current_component() === $component ) {
+		$is_current_component = true;
+	}
+
+	return $is_current_component;
+}
+add_filter( 'bp_is_current_component', __NAMESPACE__ . '\bp_is_current_component', 1, 2 );
+
+/**
  * Adds backward compatibility when `bp_current_action()` is called too early.
  *
  * @since ?.0.0

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -77,7 +77,7 @@ add_filter( 'bp_current_component', __NAMESPACE__ . '\bp_current_component', 1, 
  *
  * @since ?.0.0
  *
- * @param string $current_action False if the current action is not set yet. The component action name otherwise.
+ * @param string $current_action Empty string if the current action is not set yet. The component action name otherwise.
  * @return null|string           Null if the current action is not set yet. The component action name otherwise.
  */
 function bp_current_action( $current_action = '' ) {
@@ -88,3 +88,37 @@ function bp_current_action( $current_action = '' ) {
 	return $current_action;
 }
 add_filter( 'bp_current_action', __NAMESPACE__ . '\bp_current_action', 1, 1 );
+
+/**
+ * Adds backward compatibility when `bp_current_item()` is called too early.
+ *
+ * @since ?.0.0
+ *
+ * @param false|string $current_item False if the current item is not set yet. The single item slug otherwise.
+ * @return null|string               Null if the current item is not set yet. The single item slug otherwise.
+ */
+function bp_current_item( $current_item = '' ) {
+	if ( ! $current_item ) {
+		$current_item = _was_called_too_early( 'bp_current_item()', 'current_item' );
+	}
+
+	return $current_item;
+}
+add_filter( 'bp_current_item', __NAMESPACE__ . '\bp_current_item', 1, 1 );
+
+/**
+ * Adds backward compatibility when `bp_action_variables()` is called too early.
+ *
+ * @since ?.0.0
+ *
+ * @param false|array $action_variables False if the action variables are not set yet. The action variables otherwise.
+ * @return null|array                   Null if the action variables are not set yet. The action variables otherwise.
+ */
+function bp_action_variables( $action_variables = array() ) {
+	if ( ! $action_variables ) {
+		$action_variables = _was_called_too_early( 'bp_action_variables()', 'action_variables' );
+	}
+
+	return $action_variables;
+}
+add_filter( 'bp_action_variables', __NAMESPACE__ . '\bp_action_variables', 1, 1 );

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Core component template tag functions.
+ *
+ * @package buddypress\bp-core
+ * @since 1.5.0
+ */
+
+namespace BP\Rewrites;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * This private function checks if a BuddyPress function retrieving a BuddyPress global was called too early.
+ *
+ * Doing this check inside `BuddyPress::__get()` would probably be better to improve this backcompat mechanism.
+ *
+ * @since ?.0.0
+ *
+ * @param string $function  The function name. Required.
+ * @param string $bp_global The BuddyPress global name. Required.
+ * @return mixed            The BuddyPress global value set using the BP Legacy URL parser.
+ */
+function _was_called_too_early( $function, $bp_global ) {
+	$retval = null;
+
+	if ( did_action( 'bp_parse_query' ) ) {
+		return $retval;
+	}
+
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		ob_start();
+		_doing_it_wrong( esc_html( $function ), esc_html__( 'Please wait for the `bp_parse_query` hook to be fired before using it.' ), 'TBD' );
+		$doing_it_wrong = ob_get_clean();
+
+		$debug_backtrace = explode( ', ' . esc_html( rtrim( $function, '()' ) ), wp_debug_backtrace_summary() ); // phpcs:ignore
+		$debug_backtrace = reset( $debug_backtrace );
+
+		printf(
+			'<div style="border-left: solid 4px red; padding: 0 1em; margin: 1em">
+				%s
+			</div>',
+			wpautop( $doing_it_wrong . "\n" . $debug_backtrace . ".\n" ) // phpcs:ignore
+		);
+	}
+
+	/*
+	 * @todo Set the requested BP Global using the BP Legacy URL parser.
+	 */
+	$retval = null;
+
+	return $retval;
+}
+
+/**
+ * Adds backward compatibility when `\bp_current_component()` is called too early.
+ *
+ * @since ?.0.0
+ *
+ * @param false|string $current_component False if the current component is not set yet. The component name otherwise.
+ * @return null|string                    Null if the current component is not set yet. The component name otherwise.
+ */
+function bp_current_component( $current_component = false ) {
+	if ( ! $current_component ) {
+		$current_component = _was_called_too_early( 'bp_current_component()', 'current_component' );
+	}
+
+	return $current_component;
+}
+add_filter( 'bp_current_component', __NAMESPACE__ . '\bp_current_component', 1, 1 );
+
+/**
+ * Adds backward compatibility when `bp_current_action()` is called too early.
+ *
+ * @since ?.0.0
+ *
+ * @param string $current_action False if the current action is not set yet. The component action name otherwise.
+ * @return null|string           Null if the current action is not set yet. The component action name otherwise.
+ */
+function bp_current_action( $current_action = '' ) {
+	if ( ! $current_action ) {
+		$current_component = _was_called_too_early( 'bp_current_action()', 'current_action' );
+	}
+
+	return $current_action;
+}
+add_filter( 'bp_current_action', __NAMESPACE__ . '\bp_current_action', 1, 1 );

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since ?.0.0
  *
  * @param string $function  The function name. Required.
- * @param array  $bp_global The BuddyPress global name. Required.
+ * @param array  $bp_global An array containing the BuddyPress global name. Required.
  * @return mixed            The BuddyPress global value set using the BP Legacy URL parser.
  */
 function _was_called_too_early( $function, $bp_global ) {
@@ -56,12 +56,8 @@ function _was_called_too_early( $function, $bp_global ) {
 		}
 	}
 
-	/*
-	 * @todo Set the requested BP Global using the BP Legacy URL parser.
-	 */
-	$retval = null;
-
-	return $retval;
+	// Get the requested BP Global using the BP Legacy URL parser.
+	return bp_core_get_from_uri( $bp_global );
 }
 
 /**
@@ -91,7 +87,7 @@ add_filter( 'bp_current_component', __NAMESPACE__ . '\bp_current_component', 1, 
  */
 function bp_current_action( $current_action = '' ) {
 	if ( ! $current_action ) {
-		$current_component = _was_called_too_early( 'bp_current_action()', array( 'current_action' ) );
+		$current_action = _was_called_too_early( 'bp_current_action()', array( 'current_action' ) );
 	}
 
 	return $current_action;

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -21,30 +21,39 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since ?.0.0
  *
  * @param string $function  The function name. Required.
- * @param string $bp_global The BuddyPress global name. Required.
+ * @param array  $bp_global The BuddyPress global name. Required.
  * @return mixed            The BuddyPress global value set using the BP Legacy URL parser.
  */
 function _was_called_too_early( $function, $bp_global ) {
-	$retval = null;
+	$retval   = null;
+	$is_admin = is_admin() && ! wp_doing_ajax();
 
-	if ( did_action( 'bp_parse_query' ) ) {
+	// `bp_parse_query` is not fired in WP Admin.
+	if ( did_action( 'bp_parse_query' ) || $is_admin ) {
 		return $retval;
 	}
 
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-		ob_start();
-		_doing_it_wrong( esc_html( $function ), esc_html__( 'Please wait for the `bp_parse_query` hook to be fired before using it.' ), 'TBD' );
-		$doing_it_wrong = ob_get_clean();
-
 		$debug_backtrace = explode( ', ' . esc_html( rtrim( $function, '()' ) ), wp_debug_backtrace_summary() ); // phpcs:ignore
 		$debug_backtrace = reset( $debug_backtrace );
 
-		printf(
-			'<div style="border-left: solid 4px red; padding: 0 1em; margin: 1em">
-				%s
-			</div>',
-			wpautop( $doing_it_wrong . "\n" . $debug_backtrace . ".\n" ) // phpcs:ignore
-		);
+		/*
+		 * `BP_Core::setup_globals()` checks the displayed user ID too early when using `bp_user_has_access()`.
+		 *
+		 * While overriding BP Core could be done, let's just ignore this exception for now.
+		 */
+		if ( false === strpos( $debug_backtrace, 'BP_Core->setup_globals, bp_user_has_access' ) ) {
+			ob_start();
+			_doing_it_wrong( esc_html( $function ), esc_html__( 'Please wait for the `bp_parse_query` hook to be fired before using it.' ), 'TBD' );
+			$doing_it_wrong = ob_get_clean();
+
+			printf(
+				'<div style="border-left: solid 4px red; padding: 0 1em; margin: 1em">
+					%s
+				</div>',
+				wpautop( $doing_it_wrong . "\n" . $debug_backtrace . ".\n" ) // phpcs:ignore
+			);
+		}
 	}
 
 	/*
@@ -65,7 +74,7 @@ function _was_called_too_early( $function, $bp_global ) {
  */
 function bp_current_component( $current_component = false ) {
 	if ( ! $current_component ) {
-		$current_component = _was_called_too_early( 'bp_current_component()', 'current_component' );
+		$current_component = _was_called_too_early( 'bp_current_component()', array( 'current_component' ) );
 	}
 
 	return $current_component;
@@ -82,7 +91,7 @@ add_filter( 'bp_current_component', __NAMESPACE__ . '\bp_current_component', 1, 
  */
 function bp_current_action( $current_action = '' ) {
 	if ( ! $current_action ) {
-		$current_component = _was_called_too_early( 'bp_current_action()', 'current_action' );
+		$current_component = _was_called_too_early( 'bp_current_action()', array( 'current_action' ) );
 	}
 
 	return $current_action;
@@ -99,7 +108,7 @@ add_filter( 'bp_current_action', __NAMESPACE__ . '\bp_current_action', 1, 1 );
  */
 function bp_current_item( $current_item = '' ) {
 	if ( ! $current_item ) {
-		$current_item = _was_called_too_early( 'bp_current_item()', 'current_item' );
+		$current_item = _was_called_too_early( 'bp_current_item()', array( 'current_item' ) );
 	}
 
 	return $current_item;
@@ -116,9 +125,26 @@ add_filter( 'bp_current_item', __NAMESPACE__ . '\bp_current_item', 1, 1 );
  */
 function bp_action_variables( $action_variables = array() ) {
 	if ( ! $action_variables ) {
-		$action_variables = _was_called_too_early( 'bp_action_variables()', 'action_variables' );
+		$action_variables = _was_called_too_early( 'bp_action_variables()', array( 'action_variables' ) );
 	}
 
 	return $action_variables;
 }
 add_filter( 'bp_action_variables', __NAMESPACE__ . '\bp_action_variables', 1, 1 );
+
+/**
+ * Adds backward compatibility when `bp_displayed_user_id()` is called too early.
+ *
+ * @since ?.0.0
+ *
+ * @param int $user_id 0 if the displayed user ID is not set yet. The the displayed user ID otherwise.
+ * @return null|int    Null if the the displayed user ID is not set yet. The the displayed user ID otherwise.
+ */
+function bp_displayed_user_id( $user_id = 0 ) {
+	if ( ! $user_id ) {
+		$user_id = _was_called_too_early( 'bp_displayed_user_id()', array( 'displayed_user', 'id' ) );
+	}
+
+	return $user_id;
+}
+add_filter( 'bp_displayed_user_id', __NAMESPACE__ . '\bp_displayed_user_id', 1, 1 );

--- a/src/bp-groups/actions/create.php
+++ b/src/bp-groups/actions/create.php
@@ -13,15 +13,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/*
- * @todo `groups_action_create_group()` should be edited so that `bp_get_groups_directory_permalink() . 'create/step/'`
- * is replaced by `bp_get_group_create_link()`.
- */
-
 /**
- * Catch and process group creation form submissions.
+ * `\groups_action_create_group()` needs to be edited to allow slug customization and use BP Rewrites.
  *
- * @since 1.2.0
+ * @since ?.0.0
  *
  * @return bool
  */

--- a/src/bp-groups/bp-groups-filters.php
+++ b/src/bp-groups/bp-groups-filters.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * BuddyPress Groups Filters.
+ *
+ * @package buddypress\bp-groups
+ * @since ?.0.0
+ */
+
+namespace BP\Rewrites;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * `\bp_groups_user_can_filter` should wait the `bp_groups_parse_query` hook has fired before
+ * trying to get the current group ID.
+ *
+ * @since ?.0.0
+ *
+ * @param bool   $retval     Whether or not the current user has the capability.
+ * @param int    $user_id    The user ID.
+ * @param string $capability The capability being checked for.
+ * @param int    $site_id    Site ID. Defaults to the BP root blog.
+ * @param array  $args       Array of extra arguments passed.
+ *
+ * @return bool
+ */
+function bp_groups_user_can_filter( $retval, $user_id, $capability, $site_id, $args ) {
+	$group_caps = array(
+		'groups_join_group',
+		'groups_request_membership',
+		'groups_send_invitation',
+		'groups_receive_invitation',
+		'groups_access_group',
+		'groups_see_group',
+	);
+
+	if ( ! in_array( $capability, $group_caps, true ) ) {
+		return $retval;
+	}
+
+	if ( ! empty( $args['group_id'] ) || did_action( 'bp_groups_parse_query' ) ) {
+		$retval = \bp_groups_user_can_filter( $retval, $user_id, $capability, $site_id, $args );
+	}
+
+	return $retval;
+}
+
+/**
+ * `\bp_groups_user_can_filter` can happen before the Groups component is fully set.
+ *
+ * @since ?.0.0
+ */
+function do_it_right_groups_user_can_filter() {
+	remove_filter( 'bp_user_can', 'bp_groups_user_can_filter', 10, 5 );
+	add_filter( 'bp_user_can', __NAMESPACE__ . '\bp_groups_user_can_filter', 10, 5 );
+}
+add_action( 'bp_init', __NAMESPACE__ . '\do_it_right_groups_user_can_filter', 1 );

--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -31,6 +31,23 @@ function groups_get_current_group( $current_group = false ) {
 add_filter( 'groups_get_current_group', __NAMESPACE__ . '\groups_get_current_group', 1, 1 );
 
 /**
+ * Adds backward compatibility when `bp_get_current_group_directory_type()` is called too early.
+ *
+ * @since ?.0.0
+ *
+ * @param string $current_directory_type Empty string if the current group type is not set yet. The group type otherwise.
+ * @return null|string           Null if the current group type is not set yet. The group type name otherwise.
+ */
+function bp_get_current_group_directory_type( $current_directory_type = '' ) {
+	if ( ! $current_directory_type ) {
+		$current_directory_type = _was_called_too_early( 'bp_get_current_group_directory_type()', array( 'current_directory_type' ) );
+	}
+
+	return $current_directory_type;
+}
+add_filter( 'bp_get_current_group_directory_type', __NAMESPACE__ . '\bp_get_current_group_directory_type', 1, 1 );
+
+/**
  * Returns the Group restricted views.
  *
  * @since ?.0.0

--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -14,6 +14,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Adds backward compatibility when `\groups_get_current_group()` is called too early.
+ *
+ * @since ?.0.0
+ *
+ * @param false|BP_Groups_Group $current_group False if the current group is not set yet. The current Group object otherwise.
+ * @return null|BP_Groups_Group                Null if the current group is not set yet. The current Group object otherwise.
+ */
+function groups_get_current_group( $current_group = false ) {
+	if ( ! isset( $current_group->id ) ) {
+		$current_group = _was_called_too_early( 'groups_get_current_group()', array( 'current_group' ) );
+	}
+
+	return $current_group;
+}
+add_filter( 'groups_get_current_group', __NAMESPACE__ . '\groups_get_current_group', 1, 1 );
+
+/**
  * Returns the Group restricted views.
  *
  * @since ?.0.0

--- a/src/bp-groups/bp-groups-notifications.php
+++ b/src/bp-groups/bp-groups-notifications.php
@@ -105,7 +105,7 @@ function bp_groups_format_member_promoted( $content, ...$args ) {
  * @return array|string         The content of the notification with rebuilt URL.
  */
 function bp_groups_format_group_invite( $content, ...$args ) {
-	$user_id = bp_displayed_user_id();
+	$user_id = \bp_displayed_user_id();
 
 	if ( ! $user_id ) {
 		$user_id = bp_loggedin_user_id();

--- a/src/bp-groups/bp-groups-rewrites.php
+++ b/src/bp-groups/bp-groups-rewrites.php
@@ -87,7 +87,7 @@ function bp_group_rewrites_get_action_url( $action = '', $group = null, $query_a
 	}
 
 	if ( ! $group ) {
-		$group = groups_get_current_group();
+		$group = \groups_get_current_group();
 	}
 
 	if ( ! isset( $group->slug ) ) {

--- a/src/bp-groups/bp-groups-template.php
+++ b/src/bp-groups/bp-groups-template.php
@@ -171,7 +171,7 @@ add_filter( 'bp_group_admin_form_action', __NAMESPACE__ . '\bp_group_admin_form_
  * @return string                The Group form action URL built for the BP Rewrites URL parser.
  */
 function bp_group_form_action( $url = '', $group = null ) {
-	$action = bp_current_action();
+	$action = \bp_current_action();
 
 	if ( ! $action ) {
 		return $url;

--- a/src/bp-groups/bp-groups-template.php
+++ b/src/bp-groups/bp-groups-template.php
@@ -310,7 +310,7 @@ function bp_get_group_request_accept_link( $url = '' ) {
 
 	return bp_group_rewrites_get_action_url(
 		$action,
-		groups_get_current_group(),
+		\groups_get_current_group(),
 		array(
 			'user_id' => $GLOBALS['requests_template']->request->user_id,
 			'action'  => 'accept',
@@ -339,7 +339,7 @@ function bp_get_group_request_reject_link( $url = '' ) {
 
 	return bp_group_rewrites_get_action_url(
 		$action,
-		groups_get_current_group(),
+		\groups_get_current_group(),
 		array(
 			'user_id' => $GLOBALS['requests_template']->request->user_id,
 			'action'  => 'reject',

--- a/src/bp-groups/classes/class-groups-component.php
+++ b/src/bp-groups/classes/class-groups-component.php
@@ -37,7 +37,7 @@ class Groups_Component extends \BP_Groups_Component {
 		// Set includes directory.
 		$inc_dir = trailingslashit( bp_rewrites()->dir ) . 'src/bp-groups/';
 
-		if ( bp_is_groups_component() && is_user_logged_in() && 'create' === bp_current_action() ) {
+		if ( bp_is_groups_component() && is_user_logged_in() && 'create' === \bp_current_action() ) {
 			require $inc_dir . 'actions/create.php';
 		}
 
@@ -201,42 +201,6 @@ class Groups_Component extends \BP_Groups_Component {
 
 		/* Single Group Globals **********************************************/
 
-		$this->current_group = $this->set_current_group( bp_current_action() );
-
-		if ( $this->current_group ) {
-			/**
-			 * When in a single group, the first action is bumped down one because of the
-			 * group name, so we need to adjust this and set the group name to current_item.
-			 */
-			$bp->current_item   = bp_current_action();
-			$bp->current_action = bp_action_variable( 0 );
-			array_shift( $bp->action_variables );
-		}
-
-		// Set group type if available.
-		if ( bp_is_groups_directory() && bp_is_current_action( bp_get_groups_group_type_base() ) && bp_action_variable() ) {
-			$matched_types = bp_groups_get_group_types(
-				array(
-					'has_directory'  => true,
-					'directory_slug' => bp_action_variable(),
-				)
-			);
-
-			// Set 404 if we do not have a valid group type.
-			if ( empty( $matched_types ) ) {
-				bp_do_404();
-				return;
-			}
-
-			// Set our directory type marker.
-			$this->current_directory_type = reset( $matched_types );
-		}
-
-		// Set up variables specific to the group creation process.
-		if ( bp_is_groups_component() && bp_is_current_action( 'create' ) && bp_user_can_create_groups() && isset( $_COOKIE['bp_new_group_id'] ) ) {
-			$bp->groups->new_group_id = (int) $_COOKIE['bp_new_group_id'];
-		}
-
 		/**
 		 * Filters the list of illegal groups names/slugs.
 		 *
@@ -263,12 +227,6 @@ class Groups_Component extends \BP_Groups_Component {
 				$this->root_slug,
 			)
 		);
-
-		// If the user was attempting to access a group, but no group by that name was found, 404.
-		if ( bp_is_groups_component() && empty( $this->current_group ) && empty( $this->current_directory_type ) && bp_current_action() && ! in_array( bp_current_action(), $this->forbidden_names, true ) ) {
-			bp_do_404();
-			return;
-		}
 
 		/**
 		 * Filters the preconfigured groups creation steps.
@@ -326,7 +284,7 @@ class Groups_Component extends \BP_Groups_Component {
 		$bp = buddypress();
 
 		if ( bp_is_groups_component() && isset( $this->current_group->id ) && $this->current_group->id ) {
-			$current_action = bp_current_action();
+			$current_action = \bp_current_action();
 
 			if ( $current_action ) {
 				// The action is stored as a slug, Rewrite IDs are keys: dashes need to be replaced by underscores.
@@ -765,6 +723,7 @@ class Groups_Component extends \BP_Groups_Component {
 				$this->current_group = $this->set_current_group( $group_slug );
 
 				if ( ! $this->current_group ) {
+					$bp->current_component = false;
 					bp_do_404();
 					return;
 				}
@@ -828,6 +787,7 @@ class Groups_Component extends \BP_Groups_Component {
 					$bp->current_action           = bp_get_groups_group_type_base();
 					$bp->action_variables         = array( $group_type_slug );
 				} else {
+					$bp->current_component = false;
 					bp_do_404();
 					return;
 				}

--- a/src/bp-groups/classes/class-groups-component.php
+++ b/src/bp-groups/classes/class-groups-component.php
@@ -130,58 +130,12 @@ class Groups_Component extends \BP_Groups_Component {
 	}
 
 	/**
-	 * Override the method to set up Groups component global variables.
+	 * Set up additional globals for the component.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @see BP_Component::setup_globals() for a description of arguments.
-	 *
-	 * @param array $args See BP_Component::setup_globals() for a description.
 	 */
-	public function setup_globals( $args = array() ) {
+	public function setup_additional_globals() {
 		$bp = buddypress();
-
-		// Define a slug, if necessary.
-		if ( ! defined( 'BP_GROUPS_SLUG' ) ) {
-			define( 'BP_GROUPS_SLUG', $this->id );
-		}
-
-		// Global tables for groups component.
-		$global_tables = array(
-			'table_name'           => $bp->table_prefix . 'bp_groups',
-			'table_name_members'   => $bp->table_prefix . 'bp_groups_members',
-			'table_name_groupmeta' => $bp->table_prefix . 'bp_groups_groupmeta',
-		);
-
-		// Metadata tables for groups component.
-		$meta_tables = array(
-			'group' => $bp->table_prefix . 'bp_groups_groupmeta',
-		);
-
-		// Fetch the default directory title.
-		$default_directory_titles = bp_core_get_directory_page_default_titles();
-		$default_directory_title  = $default_directory_titles[ $this->id ];
-
-		// All globals for groups component.
-		// Note that global_tables is included in this array.
-		$args = array(
-			'slug'                  => BP_GROUPS_SLUG,
-			'root_slug'             => isset( $bp->pages->groups->slug ) ? $bp->pages->groups->slug : BP_GROUPS_SLUG,
-			'has_directory'         => true,
-			'directory_title'       => isset( $bp->pages->groups->title ) ? $bp->pages->groups->title : $default_directory_title,
-			'notification_callback' => 'groups_format_notifications',
-			'search_string'         => _x( 'Search Groups...', 'Component directory search', 'buddypress' ),
-			'global_tables'         => $global_tables,
-			'meta_tables'           => $meta_tables,
-			'block_globals'         => array(
-				'bp/dynamic-groups' => array(
-					'widget_classnames' => array( 'widget_bp_groups_widget', 'buddypress' ),
-				),
-			),
-		);
-
-		// Run the setup hook.
-		\BP_Component::setup_globals( $args );
 
 		// Set Rewrites globals.
 		bp_component_setup_globals(

--- a/src/bp-groups/screens/single/admin.php
+++ b/src/bp-groups/screens/single/admin.php
@@ -27,5 +27,5 @@ function groups_screen_group_admin() {
 		return false;
 	}
 
-	bp_core_redirect( bp_group_admin_rewrites_get_form_url( groups_get_current_group(), 'edit-details', 'bp_group_manage_edit_details' ) );
+	bp_core_redirect( bp_group_admin_rewrites_get_form_url( \groups_get_current_group(), 'edit-details', 'bp_group_manage_edit_details' ) );
 }

--- a/src/bp-groups/screens/single/admin.php
+++ b/src/bp-groups/screens/single/admin.php
@@ -23,7 +23,7 @@ function groups_screen_group_admin() {
 		return false;
 	}
 
-	if ( bp_action_variables() ) {
+	if ( \bp_action_variables() ) {
 		return false;
 	}
 

--- a/src/bp-groups/screens/single/admin/edit-details.php
+++ b/src/bp-groups/screens/single/admin/edit-details.php
@@ -19,6 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since ?.0.0
  */
 function groups_screen_group_admin_edit_details() {
-	bp_core_redirect( bp_group_admin_rewrites_get_form_url( groups_get_current_group(), 'edit-details', 'bp_group_manage_edit_details' ) );
+	bp_core_redirect( bp_group_admin_rewrites_get_form_url( \groups_get_current_group(), 'edit-details', 'bp_group_manage_edit_details' ) );
 }
 add_action( 'groups_group_details_edited', __NAMESPACE__ . '\groups_screen_group_admin_edit_details', 1 );

--- a/src/bp-groups/screens/single/admin/group-settings.php
+++ b/src/bp-groups/screens/single/admin/group-settings.php
@@ -19,6 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since ?.0.0
  */
 function groups_screen_group_admin_settings() {
-	bp_core_redirect( bp_group_admin_rewrites_get_form_url( groups_get_current_group(), 'group-settings', 'bp_group_manage_group_settings' ) );
+	bp_core_redirect( bp_group_admin_rewrites_get_form_url( \groups_get_current_group(), 'group-settings', 'bp_group_manage_group_settings' ) );
 }
 add_action( 'groups_group_settings_edited', __NAMESPACE__ . '\groups_screen_group_admin_settings', 1 );

--- a/src/bp-groups/screens/single/admin/manage-members.php
+++ b/src/bp-groups/screens/single/admin/manage-members.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since ?.0.0
  */
 function groups_screen_group_admin_manage_members() {
-	bp_core_redirect( bp_group_admin_rewrites_get_form_url( groups_get_current_group(), 'manage-members', 'bp_group_manage_manage_members' ) );
+	bp_core_redirect( bp_group_admin_rewrites_get_form_url( \groups_get_current_group(), 'manage-members', 'bp_group_manage_manage_members' ) );
 }
 add_action( 'groups_removed_member', __NAMESPACE__ . '\groups_screen_group_admin_manage_members', 1 );
 add_action( 'groups_unbanned_member', __NAMESPACE__ . '\groups_screen_group_admin_manage_members', 1 );

--- a/src/bp-groups/screens/single/admin/membership-requests.php
+++ b/src/bp-groups/screens/single/admin/membership-requests.php
@@ -19,6 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since ?.0.0
  */
 function groups_screen_group_admin_requests() {
-	bp_core_redirect( bp_group_admin_rewrites_get_form_url( groups_get_current_group(), 'membership-requests', 'bp_group_manage_membership_requests' ) );
+	bp_core_redirect( bp_group_admin_rewrites_get_form_url( \groups_get_current_group(), 'membership-requests', 'bp_group_manage_membership_requests' ) );
 }
 add_action( 'groups_group_request_managed', __NAMESPACE__ . '\groups_screen_group_admin_requests', 1 );

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -29,6 +29,23 @@ function bp_core_get_user_domain( $domain = '', $user_id = 0, $user_nicename = '
 add_filter( 'bp_core_get_user_domain', __NAMESPACE__ . '\bp_core_get_user_domain', 1, 3 );
 
 /**
+ * Adds backward compatibility when `\bp_get_current_member_type()` is called too early.
+ *
+ * @since ?.0.0
+ *
+ * @param string $current_member_type The current member type being displayed into the Members directory.
+ * @return null|string                Null if the current member type is not set yet. The current member type otherwise.
+ */
+function bp_get_current_member_type( $current_member_type = '' ) {
+	if ( ! $current_member_type ) {
+		$current_member_type = _was_called_too_early( 'bp_get_current_member_type()', array( 'current_member_type' ) );
+	}
+
+	return $current_member_type;
+}
+add_filter( 'bp_get_current_member_type', __NAMESPACE__ . '\bp_get_current_member_type', 1, 1 );
+
+/**
  * `bp_core_signup_send_validation_email()` as well as `\bp_core_activation_signup_blog_notification()` need to use BP Rewrites
  * to build the `activate.url` Email tokens argument.
  *

--- a/src/bp-members/bp-members-rewrites.php
+++ b/src/bp-members/bp-members-rewrites.php
@@ -32,7 +32,7 @@ function bp_members_rewrites_get_nav_url( $args = array() ) {
 	$params = bp_parse_args(
 		$args,
 		array(
-			'user_id'        => bp_displayed_user_id(),
+			'user_id'        => \bp_displayed_user_id(),
 			'rewrite_id'     => '',
 			'item_component' => '',
 			'item_action'    => '',

--- a/src/bp-members/classes/class-members-component.php
+++ b/src/bp-members/classes/class-members-component.php
@@ -87,12 +87,12 @@ class Members_Component extends \BP_Members_Component {
 
 		if ( bp_displayed_user_id() ) {
 			$bp->canonical_stack['base_url'] = bp_member_rewrites_get_url( bp_displayed_user_id() );
-			$item_component                  = bp_current_component();
+			$item_component                  = \bp_current_component();
 
 			if ( $item_component ) {
 				$bp->canonical_stack['component'] = bp_rewrites_get_slug( 'members', 'bp_member_' . $item_component, $item_component );
 
-				if ( isset( $bp->default_component ) && bp_is_current_component( $bp->default_component ) && ! bp_current_action() ) {
+				if ( isset( $bp->default_component ) && bp_is_current_component( $bp->default_component ) && ! \bp_current_action() ) {
 					unset( $bp->canonical_stack['component'] );
 				}
 			}

--- a/src/bp-members/classes/class-members-component.php
+++ b/src/bp-members/classes/class-members-component.php
@@ -477,6 +477,19 @@ class Members_Component extends \BP_Members_Component {
 			$member_type_slug      = $query->get( $this->rewrite_ids['directory_type'] );
 
 			if ( $member_slug ) {
+				/**
+				 * Filter the portion of the URI that is the displayed user's slug.
+				 *
+				 * Eg. example.com/ADMIN (when root profiles is enabled)
+				 *     example.com/members/ADMIN (when root profiles isn't enabled)
+				 *
+				 * ADMIN would be the displayed user's slug.
+				 *
+				 * @since 2.6.0
+				 *
+				 * @param string $member_slug
+				 */
+				$member_slug           = apply_filters( 'bp_core_set_uri_globals_member_slug', $member_slug );
 				$bp->current_component = '';
 
 				// Unless root profiles are on, the member shouldn't be set yet.

--- a/src/bp-members/classes/class-members-component.php
+++ b/src/bp-members/classes/class-members-component.php
@@ -120,7 +120,7 @@ class Members_Component extends \BP_Members_Component {
 			if ( $item_component ) {
 				$bp->canonical_stack['component'] = bp_rewrites_get_slug( 'members', 'bp_member_' . $item_component, $item_component );
 
-				if ( isset( $bp->default_component ) && bp_is_current_component( $bp->default_component ) && ! \bp_current_action() ) {
+				if ( isset( $bp->default_component ) && \bp_is_current_component( $bp->default_component ) && ! \bp_current_action() ) {
 					unset( $bp->canonical_stack['component'] );
 				}
 			}

--- a/src/bp-settings/actions/general.php
+++ b/src/bp-settings/actions/general.php
@@ -45,7 +45,7 @@ function bp_settings_action_general_verify_email_change( $args = array() ) {
 			add_query_arg(
 				$query_vars,
 				bp_member_rewrites_get_url(
-					bp_displayed_user_id(),
+					\bp_displayed_user_id(),
 					'',
 					array(
 						'single_item_component' => bp_rewrites_get_slug( 'members', $rewrite_id, $slug ),

--- a/src/bp-settings/bp-settings-templates.php
+++ b/src/bp-settings/bp-settings-templates.php
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function bp_settings_get_member_url( $user_id = 0, $query_vars = array(), $nonce = false ) {
 	if ( ! $user_id ) {
-		$user_id = bp_displayed_user_id();
+		$user_id = \bp_displayed_user_id();
 	}
 
 	$slug       = bp_get_settings_slug();
@@ -58,7 +58,7 @@ function bp_settings_pending_email_notice() {
 	// Remove the BuddyPress hook to replace it by BP Rewrites one.
 	remove_action( 'bp_before_member_settings_template', 'bp_settings_pending_email_notice' );
 
-	$pending_email = bp_get_user_meta( bp_displayed_user_id(), 'pending_email_change', true );
+	$pending_email = bp_get_user_meta( \bp_displayed_user_id(), 'pending_email_change', true );
 
 	if ( empty( $pending_email['newemail'] ) ) {
 		return;

--- a/src/bp-settings/classes/class-settings-component.php
+++ b/src/bp-settings/classes/class-settings-component.php
@@ -39,12 +39,12 @@ class Settings_Component extends \BP_Settings_Component {
 
 			// Authenticated actions.
 			if ( is_user_logged_in() ) {
-				if ( ! bp_current_action() || bp_is_current_action( 'general' ) ) {
+				if ( ! \bp_current_action() || bp_is_current_action( 'general' ) ) {
 					require $inc_dir . 'actions/general.php';
 
 					// Specific to post requests.
-				} elseif ( in_array( bp_current_action(), $actions, true ) ) {
-					require $inc_dir . 'actions/' . bp_current_action() . '.php';
+				} elseif ( in_array( \bp_current_action(), $actions, true ) ) {
+					require $inc_dir . 'actions/' . \bp_current_action() . '.php';
 				}
 			}
 		}

--- a/src/bp-templates/bp-nouveau.php
+++ b/src/bp-templates/bp-nouveau.php
@@ -230,9 +230,12 @@ function bp_nouveau_group_invites_create_steps() {
  * @since ?.0.0
  */
 function bp_nouveau_reset_hooks() {
-	if ( bp_is_active( 'messages' ) ) {
+	if ( bp_is_active( 'notifications' ) ) {
 		remove_action( 'bp_init', 'bp_nouveau_notifications_init_filters', 20 );
 		add_action( 'bp_parse_query', 'bp_nouveau_notifications_init_filters', 20 );
+	}
+
+	if ( bp_is_active( 'messages' ) ) {
 		remove_action( 'bp_init', 'bp_nouveau_push_sitewide_notices', 99 );
 		add_action( 'bp_parse_query', 'bp_nouveau_push_sitewide_notices', 99 );
 	}

--- a/src/bp-xprofile/bp-xprofile-functions.php
+++ b/src/bp-xprofile/bp-xprofile-functions.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * BuddyPress xProfile Functions.
+ *
+ * @package buddypress\bp-xprofile
+ * @since ?.0.0
+ */
+
+namespace BP\Rewrites;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Hooking to `bp_setup_globals` is too early, the displayed user is not set yet.
+ *
+ * @since ?.0.0
+ */
+function xprofile_override_user_fullnames() {
+	remove_action( 'bp_setup_globals', 'xprofile_override_user_fullnames', 100 );
+	add_action( 'bp_parse_query', 'xprofile_override_user_fullnames', 100 );
+}
+add_action( 'bp_setup_globals', __NAMESPACE__ . '\xprofile_override_user_fullnames', 1, 1 );

--- a/src/bp-xprofile/bp-xprofile-rewrites.php
+++ b/src/bp-xprofile/bp-xprofile-rewrites.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * BuddyPress Members Rewrites.
+ * BuddyPress xProfile Rewrites.
  *
- * @package buddypress\bp-members
+ * @package buddypress\bp-xprofile
  * @since ?.0.0
  */
 
@@ -31,7 +31,7 @@ function bp_xprofile_rewrites_get_edit_url( $url = '', $field_group_id = 0 ) {
 	return bp_rewrites_get_url(
 		array(
 			'component_id'                 => 'members',
-			'single_item'                  => bp_rewrites_get_member_slug( bp_displayed_user_id() ),
+			'single_item'                  => bp_rewrites_get_member_slug( \bp_displayed_user_id() ),
 			'single_item_component'        => bp_rewrites_get_slug( 'members', 'bp_member_profile', bp_get_profile_slug() ),
 			'single_item_action'           => 'edit',
 			'single_item_action_variables' => array( 'group', $field_group_id ),

--- a/src/bp-xprofile/classes/class-xprofile-component.php
+++ b/src/bp-xprofile/classes/class-xprofile-component.php
@@ -36,7 +36,7 @@ class XProfile_Component extends \BP_XProfile_Component {
 			// Set includes directory.
 			$inc_dir = trailingslashit( bp_rewrites()->dir ) . 'src/bp-xprofile/';
 
-			if ( bp_is_profile_component() && 'edit' === bp_current_action() ) {
+			if ( bp_is_profile_component() && 'edit' === \bp_current_action() ) {
 				require $inc_dir . 'screens/edit.php';
 			}
 

--- a/src/bp-xprofile/screens/edit.php
+++ b/src/bp-xprofile/screens/edit.php
@@ -109,19 +109,19 @@ function xprofile_screen_edit_profile() {
 				 * whether an activity item should be posted.
 				 */
 				$old_values[ $field_id ] = array(
-					'value'      => xprofile_get_field_data( $field_id, bp_displayed_user_id() ),
-					'visibility' => xprofile_get_field_visibility_level( $field_id, bp_displayed_user_id() ),
+					'value'      => xprofile_get_field_data( $field_id, \bp_displayed_user_id() ),
+					'visibility' => xprofile_get_field_visibility_level( $field_id, \bp_displayed_user_id() ),
 				);
 
 				// Update the field data and visibility level.
-				xprofile_set_field_visibility_level( $field_id, bp_displayed_user_id(), $visibility_level );
+				xprofile_set_field_visibility_level( $field_id, \bp_displayed_user_id(), $visibility_level );
 
-				$field_updated = xprofile_set_field_data( $field_id, bp_displayed_user_id(), $value, $is_required[ $field_id ] );
-				$value         = xprofile_get_field_data( $field_id, bp_displayed_user_id() );
+				$field_updated = xprofile_set_field_data( $field_id, \bp_displayed_user_id(), $value, $is_required[ $field_id ] );
+				$value         = xprofile_get_field_data( $field_id, \bp_displayed_user_id() );
 
 				$new_values[ $field_id ] = array(
 					'value'      => $value,
-					'visibility' => xprofile_get_field_visibility_level( $field_id, bp_displayed_user_id() ),
+					'visibility' => xprofile_get_field_visibility_level( $field_id, \bp_displayed_user_id() ),
 				);
 
 				if ( ! $field_updated ) {
@@ -151,14 +151,14 @@ function xprofile_screen_edit_profile() {
 			 * @param array $old_values       Array of original values before updated.
 			 * @param array $new_values       Array of newly saved values after update.
 			 */
-			do_action( 'xprofile_updated_profile', bp_displayed_user_id(), $posted_field_ids, $errors, $old_values, $new_values );
+			do_action( 'xprofile_updated_profile', \bp_displayed_user_id(), $posted_field_ids, $errors, $old_values, $new_values );
 
 			// Some WP User keys have been updated: let's update the WP fiels all together.
 			if ( $bp_displayed_user->updated_keys ) {
 				$user_id = wp_update_user(
 					array_merge(
 						array(
-							'ID' => bp_displayed_user_id(),
+							'ID' => \bp_displayed_user_id(),
 						),
 						$bp_displayed_user->updated_keys
 					)


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
- Adds filters to check there were called after `bp_parse_query` happened on these key functions:
 - `bp_current_component()`,
 - `bp_is_current_component()`,
 - `bp_current_action()`,
 - `bp_current_item()`,
 - `bp_action_variables()`,
 - `bp_displayed_user_id()`,
 - `bp_get_current_member_type()`,
 - `groups_get_current_group()`,
 - `bp_get_current_group_directory_type()`.

If one of these functions was called too early a `_doing_it_wrong()` feedback is displayed to invite the plugin author to wait for `bp_parse_query` to happen before using the function. The feedback includes a debug trace to find where the function was used.
The value of the function is returned thanks to a specific function (`bp_core_get_from_uri()`, inspired by @r-a-y 's work on [#4954](https://buddypress.trac.wordpress.org/attachment/ticket/4954/4954.ray.01.patch)) that uses the BP Legacy URI parser + a specific "slug customizations translation" to regular BuddyPress slugs (e.g.: if the Group's Manage slug has been customized from `admin` to `gerer`, it returns `admin`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I've tested this PR manually having the [BP Docs](https://wordpress.org/plugins/buddypress-docs/) plugin activated.

## Screenshots <!-- if applicable -->
![bp-docs-groups-ok](https://user-images.githubusercontent.com/1834524/130664768-1450b41e-7a0c-4436-b28e-bf51265ca790.png)

_BP Docs in a Group_

![example-notice](https://user-images.githubusercontent.com/1834524/130664847-cb2e4ba0-2f25-4c93-9210-5ca8e13d99b2.png)

_Doing it wrong notice example_

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Backward compatibility for plugins using the BP Legacy URL parser.

=> It should fix #7 

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
