### PR TITLE
Restore the BP Directory as homepage feature support

### DIFF
--- a/src/bp-activity/classes/class-activity-component.php
+++ b/src/bp-activity/classes/class-activity-component.php
@@ -293,6 +293,10 @@ class Activity_Component extends \BP_Activity_Component {
 	 *                        description.
 	 */
 	public function parse_query( $query ) {
+		if ( bp_is_directory_homepage( $this->id ) ) {
+			$query->set( $this->rewrite_ids['directory'], 1 );
+		}
+
 		if ( 1 === (int) $query->get( $this->rewrite_ids['directory'] ) ) {
 			$bp = buddypress();
 

--- a/src/bp-blogs/classes/class-blogs-component.php
+++ b/src/bp-blogs/classes/class-blogs-component.php
@@ -291,6 +291,10 @@ class Blogs_Component extends \BP_Blogs_Component {
 		// Get the BuddyPress main instance.
 		$bp = buddypress();
 
+		if ( bp_is_directory_homepage( $this->id ) ) {
+			$query->set( $this->rewrite_ids['directory'], 1 );
+		}
+
 		if ( 1 === (int) $query->get( $this->rewrite_ids['directory'] ) ) {
 			$bp->current_component = 'blogs';
 

--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -22,8 +22,8 @@ function bp_core_load_template() {
 	if ( 'bp_core_pre_load_template' === current_action() || ( 'bp_setup_theme_compat' === current_action() && is_buddypress() ) ) {
 		global $wp_query;
 
-		// BuddyPress is not home!
-		$wp_query->is_home = false;
+		// Check if a BuddyPress component's direcory is set as homepage.
+		$wp_query->is_home = bp_is_directory_homepage( \bp_current_component() );
 	}
 }
 add_action( 'bp_core_pre_load_template', __NAMESPACE__ . '\bp_core_load_template' );

--- a/src/bp-core/bp-core-filters.php
+++ b/src/bp-core/bp-core-filters.php
@@ -29,3 +29,73 @@ function bp_core_activation_signup_blog_notification( $args = array() ) {
 	return $args;
 }
 add_filter( 'bp_before_send_email_parse_args', __NAMESPACE__ . '\bp_core_activation_signup_blog_notification', 10, 1 );
+
+/**
+ * Eventually appendf BuddyPress directories to WP Dropdown's pages control.
+ *
+ * @since ?.0.0
+ *
+ * @param WP_Post[] $pages Array of page objects.
+ * @param array     $args  Array of get_pages() arguments.
+ * @return WP_Post[]       Array of page objects, potentially including BP directories.
+ */
+function bp_core_include_directory_on_front( $pages = array(), $args = array() ) {
+	$is_page_on_front_dropdown = false;
+
+	if ( isset( $args['name'] ) ) {
+		$is_page_on_front_dropdown = 'page_on_front' === $args['name'];
+
+		if ( is_customize_preview() ) {
+			$is_page_on_front_dropdown = '_customize-dropdown-pages-page_on_front' === $args['name'];
+		}
+	}
+
+	if ( $is_page_on_front_dropdown ) {
+		$directories = bp_core_get_directory_pages();
+		$null        = '0000-00-00 00:00:00';
+
+		foreach ( (array) $directories as $component => $directory ) {
+			if ( 'activate' === $component || 'register' === $component ) {
+				continue;
+			}
+
+			$post = (object) array(
+				'ID'                    => $directory->id,
+				'post_author'           => 0,
+				'post_date'             => $null,
+				'post_date_gmt'         => $null,
+				'post_content'          => '',
+				'post_title'            => $directory->title,
+				'post_excerpt'          => '',
+				'post_status'           => 'publish',
+				'comment_status'        => 'closed',
+				'ping_status'           => 'closed',
+				'post_password'         => '',
+				'post_name'             => $directory->slug,
+				'pinged'                => '',
+				'to_ping'               => '',
+				'post_modified'         => $null,
+				'post_modified_gmt'     => $null,
+				'post_content_filtered' => '',
+				'post_parent'           => 0,
+				'guid'                  => bp_rewrites_get_url(
+					array(
+						'component_id' => $component,
+					)
+				),
+				'menu_order'            => 0,
+				'post_type'             => 'buddypress',
+				'post_mime_type'        => '',
+				'comment_count'         => 0,
+				'filter'                => 'raw',
+			);
+
+			$pages[] = get_post( $post );
+		}
+
+		$pages = bp_alpha_sort_by_key( $pages, 'post_title' );
+	}
+
+	return $pages;
+}
+add_filter( 'get_pages', __NAMESPACE__ . '\bp_core_include_directory_on_front', 10, 2 );

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -150,3 +150,25 @@ function bp_page_directory_link( $link, \WP_Post $post ) {
 	return bp_rewrites_get_url( array( 'component_id' => $component ) );
 }
 add_filter( 'post_type_link', __NAMESPACE__ . '\bp_page_directory_link', 1, 2 );
+
+/**
+ * Checks if a component's directory is set as the site's homepage.
+ *
+ * @since ?.0.0
+ *
+ * @param string $component The component ID.
+ * @return bool True if a component's directory is set as the site's homepage.
+ *              False otherwise.
+ */
+function bp_is_directory_homepage( $component = '' ) {
+	$is_directory_homepage = false;
+	$is_page_on_front      = 'page' === get_option( 'show_on_front', 'posts' );
+	$page_id_on_front      = get_option( 'page_on_front', 0 );
+	$directory_pages       = bp_core_get_directory_pages();
+
+	if ( $is_page_on_front && isset( $directory_pages->{$component} ) && (int) $page_id_on_front === (int) $directory_pages->{$component}->id ) {
+		$is_directory_homepage = true;
+	}
+
+	return $is_directory_homepage;
+}

--- a/src/bp-groups/classes/class-groups-component.php
+++ b/src/bp-groups/classes/class-groups-component.php
@@ -689,6 +689,10 @@ class Groups_Component extends \BP_Groups_Component {
 	 *                        description.
 	 */
 	public function parse_query( $query ) {
+		if ( bp_is_directory_homepage( $this->id ) ) {
+			$query->set( $this->rewrite_ids['directory'], 1 );
+		}
+
 		if ( 1 === (int) $query->get( $this->rewrite_ids['directory'] ) ) {
 			$bp                    = buddypress();
 			$group_type            = false;

--- a/src/bp-members/classes/class-members-component.php
+++ b/src/bp-members/classes/class-members-component.php
@@ -463,6 +463,10 @@ class Members_Component extends \BP_Members_Component {
 			add_action( 'bp_screens', 'bp_members_screen_display_profile', 3 );
 		}
 
+		if ( bp_is_directory_homepage( $this->id ) ) {
+			$query->set( $this->rewrite_ids['directory'], 1 );
+		}
+
 		// Which component are we displaying?
 		$is_members_component  = 1 === (int) $query->get( $this->rewrite_ids['directory'] );
 		$is_register_component = 1 === (int) $query->get( $this->rewrite_ids['member_register'] );


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
As this PR's title says!
Fixes #11

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested locally against BP Trunk (10.0.0-alpha) and WP 5.9-alpha.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Backward compatibility change.

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
