### PR TITLE
Prepare the Admin screen to the BP 10.0.0 Admin tabs

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -58,7 +58,9 @@ function admin_load() {
 	wp_enqueue_style( 'site-health' );
 	wp_add_inline_style(
 		'site-health',
-		'#bp-admin-rewrites-form .bp-nav-slug { margin-left: 2em; display: inline-block; vertical-align: middle; }
+		'#bp-admin-rewrites-form .form-table { border: none; padding: 0; }
+		#bp-admin-rewrites-form .bp-nav-slug { margin-left: 2em; display: inline-block; vertical-align: middle; }
+		.site-health-issues-wrapper:first-of-type { margin-top: 0; }
 		.site-health-issues-wrapper .health-check-accordion { border-bottom: none; }
 		.site-health-issues-wrapper .health-check-accordion:last-of-type { border-bottom: 1px solid #c3c4c7; }'
 	);

--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -14,22 +14,32 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * This code should be in `\bp_core_get_admin_tabs()`
+ * This code should be in `\bp_core_get_admin_settings_tabs()`
  *
  * @since ?.0.0
  *
- * @param array  $tabs    Tab data.
- * @param string $context The context of use for the tabs.
- * @return array          Tab data.
+ * @param array $tabs Tabs list.
+ * @return array      Edited tabs list.
  */
-function bp_core_get_admin_tabs( $tabs = array(), $context = '' ) {
-	if ( 'settings' === $context ) {
-		$tabs['1'] = array(
-			'href' => bp_get_admin_url( add_query_arg( array( 'page' => 'bp-rewrites-settings' ), 'admin.php' ) ),
-			'name' => __( 'URLs', 'buddypress' ),
-		);
-	}
+function bp_core_get_admin_settings_tabs( $tabs = array() ) {
+	$tabs['1'] = array(
+		'id'   => 'bp-rewrites-settings',
+		'href' => bp_get_admin_url( add_query_arg( array( 'page' => 'bp-rewrites-settings' ), 'admin.php' ) ),
+		'name' => __( 'URLs', 'buddypress' ),
+	);
 
 	return $tabs;
 }
-add_filter( 'bp_core_get_admin_tabs', __NAMESPACE__ . '\bp_core_get_admin_tabs', 10, 2 );
+add_filter( 'bp_core_get_admin_settings_tabs', __NAMESPACE__ . '\bp_core_get_admin_settings_tabs', 10, 2 );
+
+/**
+ * Include the BP Rewrites tab to the Admin tabs needing specific inline styles.
+ *
+ * @since ?.0.0
+ *
+ * @param array $submenu_pages The BP_Admin submenu pages passed by reference.
+ */
+function bp_admin_submenu_pages( &$submenu_pages = array() ) {
+	$submenu_pages['settings']['bp-rewrites-settings'] = get_plugin_page_hookname( 'bp-rewrites-settings', get_settings_page() );
+}
+add_action( 'bp_admin_submenu_pages', __NAMESPACE__ . '\bp_admin_submenu_pages', 10, 1 );

--- a/src/bp-core/admin/bp-core-admin-rewrites.php
+++ b/src/bp-core/admin/bp-core-admin-rewrites.php
@@ -38,18 +38,11 @@ function bp_core_admin_rewrites_settings() {
 			$bp_pages->{$page_key} = $reordered_page;
 		}
 	}
+
+	bp_core_admin_tabbed_screen_header( __( 'BuddyPress Settings', 'buddypress' ), __( 'URLs', 'buddypress' ) );
 	?>
-	<div class="wrap">
-
-		<h1><?php esc_html_e( 'BuddyPress Settings', 'buddypress' ); ?></h1>
-
-		<h2 class="nav-tab-wrapper"><?php bp_core_admin_tabs( __( 'URLs', 'buddypress' ) ); ?></h2>
-
+	<div class="buddypress-body">
 		<div class="health-check-body">
-			<h2><?php esc_html_e( 'BuddyPress URLs', 'buddypress' ); ?></h2>
-
-			<hr class="hr-separator">
-
 			<form action="" method="post" id="bp-admin-rewrites-form">
 
 			<?php foreach ( $bp->pages as $component_id => $directory_data ) : ?>


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
BuddyPress 10.0.0 will improve its BP Admin Tabs using the "site-health" tabs styles. The changes here are making sure BP Rewrites enjoys it without the doing it wrong notice. See [#8588](https://buddypress.trac.wordpress.org/ticket/8588).

## How has this been tested?
Building the plugin / checking the extensibility of the BP Admin tabs.

## Screenshots <!-- if applicable -->

![bp-rewrites-admin-screen](https://user-images.githubusercontent.com/1834524/140578351-1b637f0f-a5d0-4735-8005-4978cb75dd68.png)

## Types of changes
Anticipation of a possible doing it wrong notice 😄 

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
