### PR TITLE
Add support for BP Core Search

### DIFF
--- a/class-bp-rewrites.php
+++ b/class-bp-rewrites.php
@@ -97,7 +97,7 @@ final class BP_Rewrites {
 function bp_rewrites() {
 	return BP_Rewrites::start();
 }
-add_action( 'bp_loaded', __NAMESPACE__ . '\bp_rewrites', 0 );
+add_action( 'bp_loaded', __NAMESPACE__ . '\bp_rewrites', -1 );
 
 /**
  * Use Activation and Deactivation to switch directory pages post type between WP pages

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -14,6 +14,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Setup the Core component.
+ *
+ * @since 1.0.0
+ */
+function override_bp_core() {
+	require_once plugin_dir_path( dirname( __FILE__ ) ) . 'src/bp-core/classes/class-core-component.php';
+
+	buddypress()->core = new Core_Component();
+}
+remove_action( 'bp_loaded', 'bp_setup_core', 0 );
+add_action( 'bp_loaded', __NAMESPACE__ . '\override_bp_core', 0 );
+
+/**
  * Setup the Activity Component.
  *
  * @since 1.0.0
@@ -113,12 +126,12 @@ function bp_setup_xprofile() {
 }
 
 /**
- * Disable BuddyPress Components.
+ * Override BuddyPress Components.
  *
  * @since 1.0.0
  */
-function disable_bp_components() {
-	// @todo Add other BP Components.
+function override_bp_components() {
+	// Avoid BP Components initialization to directly replace them by BP Rewrites ones.
 	$bp_components = array(
 		'activity'      => array(
 			'callback' => 'bp_setup_activity',
@@ -170,7 +183,7 @@ function disable_bp_components() {
 		add_action( 'bp_setup_components', __NAMESPACE__ . '\\' . $hook['callback'], $hook['priority'], 0 );
 	}
 }
-add_action( 'bp_setup_components', __NAMESPACE__ . '\disable_bp_components', 0 );
+add_action( 'bp_setup_components', __NAMESPACE__ . '\override_bp_components', 0 );
 
 /**
  * Code to move inside BP_Component::setup_globals().
@@ -420,7 +433,7 @@ function disable_buddypress_legacy_url_parser() {
 
 	// Start hooking `bp_parse_query` to setup the canonical stack & BP document title.
 	add_action( 'bp_parse_query', 'bp_setup_canonical_stack', 11 );
-	add_action( 'bp_parse_query', 'bp_core_action_search_site', 13 );
+	add_action( 'bp_parse_query', 'bp_core_action_search_site', 13, 0 );
 	add_action( 'bp_parse_query', 'bp_setup_title', 14 );
 	add_action( 'bp_parse_query', '_bp_maybe_remove_redirect_canonical', 20 );
 	add_action( 'bp_parse_query', 'bp_remove_adjacent_posts_rel_link', 20 );

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function _was_called_too_early( $function, $bp_global ) {
 	$retval   = null;
-	$request  = wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
+	$request  = wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ); // phpcs:ignore
 	$is_admin = ( false !== strpos( $request, '/wp-admin' ) || is_admin() ) && ! wp_doing_ajax();
 
 	// The BP REST API needs more work.

--- a/src/bp-core/classes/class-core-component.php
+++ b/src/bp-core/classes/class-core-component.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * BP Rewrites Core Component.
+ *
+ * @package bp-rewrites\src\bp-core\classes
+ * @since 1.0.0
+ */
+
+namespace BP\Rewrites;
+
+/**
+ * Main Groups Class.
+ *
+ * @since 1.0.0
+ */
+class Core_Component extends \BP_Core {
+
+	/**
+	 * Parse the WP_Query and eventually display the component's directory or single item.
+	 *
+	 * @since ?.0.0
+	 *
+	 * @param WP_Query $query Required. See BP_Component::parse_query() for
+	 *                        description.
+	 */
+	public function parse_query( $query ) {
+		// Search doesn't have an associated page, so we check for it separately.
+		if ( isset( $_POST['search-terms'] ) && $query->get( 'pagename' ) === bp_get_search_slug() ) { // phpcs:ignore
+			buddypress()->current_component = bp_get_search_slug();
+		}
+
+		bp_component_parse_query( $query );
+
+		\BP_Component::parse_query( $query );
+	}
+}


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
Make sure requesting a BP Global Search is well redirected to the right component's search.
Fixes #13 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Developing the rewrites adaptation code. 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Existing feature Rewrites adaptations

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
