### PR TITLE
Add support for member’s secondary nav slug customization

### DIFF
--- a/src/bp-activity/classes/class-activity-component.php
+++ b/src/bp-activity/classes/class-activity-component.php
@@ -113,22 +113,8 @@ class Activity_Component extends \BP_Activity_Component {
 		// Update the primary nav item.
 		buddypress()->members->nav->edit_nav( $main_nav, $slug );
 
-		// Get the sub nav items for this main nav.
-		$sub_nav_items = buddypress()->members->nav->get_secondary( array( 'parent_slug' => $slug ), false );
-
-		// Loop inside it to reset the link using BP Rewrites before updating it.
-		foreach ( $sub_nav_items as $sub_nav_item ) {
-			$sub_nav_item['link'] = bp_members_rewrites_get_nav_url(
-				array(
-					'rewrite_id'     => $rewrite_id,
-					'item_component' => $slug,
-					'item_action'    => $sub_nav_item['slug'],
-				)
-			);
-
-			// Update the secondary nav item.
-			buddypress()->members->nav->edit_nav( $sub_nav_item, $sub_nav_item['slug'], $slug );
-		}
+		// Update the secondary nav items.
+		reset_secondary_nav( $slug, $rewrite_id );
 	}
 
 	/**
@@ -190,7 +176,12 @@ class Activity_Component extends \BP_Activity_Component {
 				);
 
 				if ( $root_nav_parent !== $item_nav['parent'] && isset( $viewes_slugs[ $item_nav_id ] ) ) {
-					$url_params['item_action'] = $viewes_slugs[ $item_nav_id ];
+					$sub_nav_rewrite_id        = sprintf(
+						'%1$s_%2$s',
+						$rewrite_id,
+						str_replace( '-', '_', $viewes_slugs[ $item_nav_id ] )
+					);
+					$url_params['item_action'] = bp_rewrites_get_slug( 'members', $sub_nav_rewrite_id, $viewes_slugs[ $item_nav_id ] );
 				}
 
 				$wp_admin_nav[ $key_item_nav ]['href'] = bp_members_rewrites_get_nav_url( $url_params );

--- a/src/bp-blogs/classes/class-blogs-component.php
+++ b/src/bp-blogs/classes/class-blogs-component.php
@@ -94,22 +94,8 @@ class Blogs_Component extends \BP_Blogs_Component {
 		// Update the primary nav item.
 		buddypress()->members->nav->edit_nav( $main_nav, $slug );
 
-		// Get the sub nav items for this main nav.
-		$sub_nav_items = buddypress()->members->nav->get_secondary( array( 'parent_slug' => $slug ), false );
-
-		// Loop inside it to reset the link using BP Rewrites before updating it.
-		foreach ( $sub_nav_items as $sub_nav_item ) {
-			$sub_nav_item['link'] = bp_members_rewrites_get_nav_url(
-				array(
-					'rewrite_id'     => $rewrite_id,
-					'item_component' => $slug,
-					'item_action'    => $sub_nav_item['slug'],
-				)
-			);
-
-			// Update the secondary nav item.
-			buddypress()->members->nav->edit_nav( $sub_nav_item, $sub_nav_item['slug'], $slug );
-		}
+		// Update the secondary nav items.
+		reset_secondary_nav( $slug, $rewrite_id );
 	}
 
 	/**
@@ -168,7 +154,12 @@ class Blogs_Component extends \BP_Blogs_Component {
 					);
 
 					if ( $root_nav_parent !== $item_nav['parent'] && isset( $viewes_slugs[ $item_nav_id ] ) ) {
-						$url_params['item_action'] = $viewes_slugs[ $item_nav_id ];
+						$sub_nav_rewrite_id        = sprintf(
+							'%1$s_%2$s',
+							$rewrite_id,
+							str_replace( '-', '_', $viewes_slugs[ $item_nav_id ] )
+						);
+						$url_params['item_action'] = bp_rewrites_get_slug( 'members', $sub_nav_rewrite_id, $viewes_slugs[ $item_nav_id ] );
 					}
 
 					$wp_admin_nav[ $key_item_nav ]['href'] = bp_members_rewrites_get_nav_url( $url_params );

--- a/src/bp-core/admin/bp-core-admin-rewrites.php
+++ b/src/bp-core/admin/bp-core-admin-rewrites.php
@@ -39,12 +39,13 @@ function bp_core_admin_rewrites_settings() {
 		}
 	}
 
+	$bp_members_primary_nav_items = array();
+
 	bp_core_admin_tabbed_screen_header( __( 'BuddyPress Settings', 'buddypress' ), __( 'URLs', 'buddypress' ) );
 	?>
 	<div class="buddypress-body">
 		<div class="health-check-body">
 			<form action="" method="post" id="bp-admin-rewrites-form">
-
 			<?php foreach ( $bp->pages as $component_id => $directory_data ) : ?>
 				<div class="site-health-issues-wrapper">
 					<h3>
@@ -105,6 +106,8 @@ function bp_core_admin_rewrites_settings() {
 									if ( ! isset( $primary_nav_item['rewrite_id'] ) || ! $primary_nav_item['rewrite_id'] ) {
 										continue;
 									}
+
+									$bp_members_primary_nav_items[ $primary_nav_item['slug'] ] = $primary_nav_item['name'];
 									?>
 									<tr>
 										<th scope="row">
@@ -122,6 +125,43 @@ function bp_core_admin_rewrites_settings() {
 											<input type="text" class="code" name="<?php printf( 'components[%1$d][_bp_component_slugs][%2$s]', absint( $directory_data->id ), esc_attr( $primary_nav_item['rewrite_id'] ) ); ?>" id="<?php echo esc_attr( sprintf( '%s-slug', sanitize_key( $primary_nav_item['rewrite_id'] ) ) ); ?>" value="<?php echo esc_attr( bp_rewrites_get_slug( $component_id, $primary_nav_item['rewrite_id'], $primary_nav_item['slug'] ) ); ?>">
 										</td>
 									</tr>
+								<?php endforeach; ?>
+							</table>
+						</div>
+					</div>
+					<div class="health-check-accordion">
+						<h4 class="health-check-accordion-heading">
+							<button aria-expanded="false" class="health-check-accordion-trigger" aria-controls="health-check-accordion-block-member-secondary-nav" type="button">
+								<span class="title"><?php esc_html_e( 'Single Member secondary views slugs', 'buddypress' ); ?></span>
+								<span class="icon"></span>
+							</button>
+						</h4>
+						<div id="health-check-accordion-block-member-secondary-nav" class="health-check-accordion-panel" hidden="hidden">
+							<table class="form-table" role="presentation">
+								<?php foreach ( $bp_members_primary_nav_items as $bp_members_primary_nav_slug => $bp_members_primary_nav_name ) : ?>
+									<?php
+									foreach ( $bp->members->nav->get_secondary( array( 'parent_slug' => $bp_members_primary_nav_slug ) ) as $secondary_nav_item ) :
+										if ( ! isset( $secondary_nav_item['rewrite_id'] ) || ! $secondary_nav_item['rewrite_id'] ) {
+											continue;
+										}
+										?>
+										<tr>
+											<th scope="row">
+												<label class="bp-nav-slug" for="<?php echo esc_attr( sprintf( '%s-slug', sanitize_key( $secondary_nav_item['rewrite_id'] ) ) ); ?>">
+													<?php
+													printf(
+														/* translators: %s is the member secondary view name */
+														esc_html__( '"%s" slug', 'buddypress' ),
+														esc_html( _bp_strip_spans_from_title( $secondary_nav_item['name'] ) )
+													);
+													?>
+												</label>
+											</th>
+											<td>
+												<input type="text" class="code" name="<?php printf( 'components[%1$d][_bp_component_slugs][%2$s]', absint( $directory_data->id ), esc_attr( $secondary_nav_item['rewrite_id'] ) ); ?>" id="<?php echo esc_attr( sprintf( '%s-slug', sanitize_key( $secondary_nav_item['rewrite_id'] ) ) ); ?>" value="<?php echo esc_attr( bp_rewrites_get_slug( $component_id, $secondary_nav_item['rewrite_id'], $secondary_nav_item['slug'] ) ); ?>">
+											</td>
+										</tr>
+									<?php endforeach; ?>
 								<?php endforeach; ?>
 							</table>
 						</div>

--- a/src/bp-core/admin/bp-core-admin-rewrites.php
+++ b/src/bp-core/admin/bp-core-admin-rewrites.php
@@ -129,43 +129,46 @@ function bp_core_admin_rewrites_settings() {
 							</table>
 						</div>
 					</div>
-					<div class="health-check-accordion">
-						<h4 class="health-check-accordion-heading">
-							<button aria-expanded="false" class="health-check-accordion-trigger" aria-controls="health-check-accordion-block-member-secondary-nav" type="button">
-								<span class="title"><?php esc_html_e( 'Single Member secondary views slugs', 'buddypress' ); ?></span>
-								<span class="icon"></span>
-							</button>
-						</h4>
-						<div id="health-check-accordion-block-member-secondary-nav" class="health-check-accordion-panel" hidden="hidden">
-							<table class="form-table" role="presentation">
-								<?php foreach ( $bp_members_primary_nav_items as $bp_members_primary_nav_slug => $bp_members_primary_nav_name ) : ?>
-									<?php
-									foreach ( $bp->members->nav->get_secondary( array( 'parent_slug' => $bp_members_primary_nav_slug ) ) as $secondary_nav_item ) :
-										if ( ! isset( $secondary_nav_item['rewrite_id'] ) || ! $secondary_nav_item['rewrite_id'] ) {
-											continue;
-										}
-										?>
-										<tr>
-											<th scope="row">
-												<label class="bp-nav-slug" for="<?php echo esc_attr( sprintf( '%s-slug', sanitize_key( $secondary_nav_item['rewrite_id'] ) ) ); ?>">
-													<?php
-													printf(
-														/* translators: %s is the member secondary view name */
-														esc_html__( '"%s" slug', 'buddypress' ),
-														esc_html( _bp_strip_spans_from_title( $secondary_nav_item['name'] ) )
-													);
-													?>
-												</label>
-											</th>
-											<td>
-												<input type="text" class="code" name="<?php printf( 'components[%1$d][_bp_component_slugs][%2$s]', absint( $directory_data->id ), esc_attr( $secondary_nav_item['rewrite_id'] ) ); ?>" id="<?php echo esc_attr( sprintf( '%s-slug', sanitize_key( $secondary_nav_item['rewrite_id'] ) ) ); ?>" value="<?php echo esc_attr( bp_rewrites_get_slug( $component_id, $secondary_nav_item['rewrite_id'], $secondary_nav_item['slug'] ) ); ?>">
-											</td>
-										</tr>
-									<?php endforeach; ?>
-								<?php endforeach; ?>
-							</table>
+
+					<?php foreach ( $bp_members_primary_nav_items as $bp_members_primary_nav_slug => $bp_members_primary_nav_name ) : ?>
+						<div class="health-check-accordion">
+							<h4 class="health-check-accordion-heading">
+								<button aria-expanded="false" class="health-check-accordion-trigger" aria-controls="<?php echo esc_attr( sprintf( 'health-check-accordion-block-member-%s-secondary-nav', $bp_members_primary_nav_slug ) ); ?>" type="button">
+									<?php /* translators: %s is the BP Component name the secondery views belong to. */ ?>
+									<span class="title"><?php echo esc_html( sprintf( __( 'Single Member %s secondary views slugs', 'buddypress' ), _bp_strip_spans_from_title( $bp_members_primary_nav_name ) ) ); ?></span>
+									<span class="icon"></span>
+								</button>
+							</h4>
+							<div id="<?php echo esc_attr( sprintf( 'health-check-accordion-block-member-%s-secondary-nav', $bp_members_primary_nav_slug ) ); ?>" class="health-check-accordion-panel" hidden="hidden">
+								<table class="form-table" role="presentation">
+
+										<?php
+										foreach ( $bp->members->nav->get_secondary( array( 'parent_slug' => $bp_members_primary_nav_slug ) ) as $secondary_nav_item ) :
+											if ( ! isset( $secondary_nav_item['rewrite_id'] ) || ! $secondary_nav_item['rewrite_id'] ) {
+												continue;
+											}
+											?>
+											<tr>
+												<th scope="row">
+													<label class="bp-nav-slug" for="<?php echo esc_attr( sprintf( '%s-slug', sanitize_key( $secondary_nav_item['rewrite_id'] ) ) ); ?>">
+														<?php
+														printf(
+															/* translators: %s is the member secondary view name */
+															esc_html__( '"%s" slug', 'buddypress' ),
+															esc_html( _bp_strip_spans_from_title( $secondary_nav_item['name'] ) )
+														);
+														?>
+													</label>
+												</th>
+												<td>
+													<input type="text" class="code" name="<?php printf( 'components[%1$d][_bp_component_slugs][%2$s]', absint( $directory_data->id ), esc_attr( $secondary_nav_item['rewrite_id'] ) ); ?>" id="<?php echo esc_attr( sprintf( '%s-slug', sanitize_key( $secondary_nav_item['rewrite_id'] ) ) ); ?>" value="<?php echo esc_attr( bp_rewrites_get_slug( $component_id, $secondary_nav_item['rewrite_id'], $secondary_nav_item['slug'] ) ); ?>">
+												</td>
+											</tr>
+										<?php endforeach; ?>
+								</table>
+							</div>
 						</div>
-					</div>
+					<?php endforeach; ?>
 				<?php endif; ?>
 
 				<?php if ( 'groups' === $component_id ) : ?>

--- a/src/bp-friends/classes/class-friends-component.php
+++ b/src/bp-friends/classes/class-friends-component.php
@@ -73,19 +73,8 @@ class Friends_Component extends \BP_Friends_Component {
 		// Get the sub nav items for this main nav.
 		$sub_nav_items = buddypress()->members->nav->get_secondary( array( 'parent_slug' => $slug ), false );
 
-		// Loop inside it to reset the link using BP Rewrites before updating it.
-		foreach ( $sub_nav_items as $sub_nav_item ) {
-			$sub_nav_item['link'] = bp_members_rewrites_get_nav_url(
-				array(
-					'rewrite_id'     => $rewrite_id,
-					'item_component' => $slug,
-					'item_action'    => $sub_nav_item['slug'],
-				)
-			);
-
-			// Update the secondary nav item.
-			buddypress()->members->nav->edit_nav( $sub_nav_item, $sub_nav_item['slug'], $slug );
-		}
+		// Update the secondary nav items.
+		reset_secondary_nav( $slug, $rewrite_id );
 	}
 
 	/**
@@ -138,7 +127,12 @@ class Friends_Component extends \BP_Friends_Component {
 				);
 
 				if ( $root_nav_parent !== $item_nav['parent'] && isset( $viewes_slugs[ $item_nav_id ] ) ) {
-					$url_params['item_action'] = $viewes_slugs[ $item_nav_id ];
+					$sub_nav_rewrite_id        = sprintf(
+						'%1$s_%2$s',
+						$rewrite_id,
+						str_replace( '-', '_', $viewes_slugs[ $item_nav_id ] )
+					);
+					$url_params['item_action'] = bp_rewrites_get_slug( 'members', $sub_nav_rewrite_id, $viewes_slugs[ $item_nav_id ] );
 				}
 
 				$wp_admin_nav[ $key_item_nav ]['href'] = bp_members_rewrites_get_nav_url( $url_params );

--- a/src/bp-groups/classes/class-groups-component.php
+++ b/src/bp-groups/classes/class-groups-component.php
@@ -356,22 +356,8 @@ class Groups_Component extends \BP_Groups_Component {
 		// Update the primary nav item.
 		$bp->members->nav->edit_nav( $main_nav, $slug );
 
-		// Get the sub nav items for this main nav.
-		$sub_nav_items = $bp->members->nav->get_secondary( array( 'parent_slug' => $slug ), false );
-
-		// Loop inside it to reset the link using BP Rewrites before updating it.
-		foreach ( $sub_nav_items as $sub_nav_item ) {
-			$sub_nav_item['link'] = bp_members_rewrites_get_nav_url(
-				array(
-					'rewrite_id'     => $rewrite_id,
-					'item_component' => $slug,
-					'item_action'    => $sub_nav_item['slug'],
-				)
-			);
-
-			// Update the secondary nav item.
-			$bp->members->nav->edit_nav( $sub_nav_item, $sub_nav_item['slug'], $slug );
-		}
+		// Update the secondary nav items.
+		reset_secondary_nav( $slug, $rewrite_id );
 	}
 
 	/**
@@ -558,7 +544,12 @@ class Groups_Component extends \BP_Groups_Component {
 					);
 
 					if ( $root_nav_parent !== $item_nav['parent'] && isset( $viewes_slugs[ $item_nav_id ] ) ) {
-						$url_params['item_action'] = $viewes_slugs[ $item_nav_id ];
+						$sub_nav_rewrite_id        = sprintf(
+							'%1$s_%2$s',
+							$rewrite_id,
+							str_replace( '-', '_', $viewes_slugs[ $item_nav_id ] )
+						);
+						$url_params['item_action'] = bp_rewrites_get_slug( 'members', $sub_nav_rewrite_id, $viewes_slugs[ $item_nav_id ] );
 					}
 
 					$wp_admin_nav[ $key_item_nav ]['href'] = bp_members_rewrites_get_nav_url( $url_params );

--- a/src/bp-messages/classes/class-messages-component.php
+++ b/src/bp-messages/classes/class-messages-component.php
@@ -70,22 +70,8 @@ class Messages_Component extends \BP_Messages_Component {
 		// Update the primary nav item.
 		buddypress()->members->nav->edit_nav( $main_nav, $slug );
 
-		// Get the sub nav items for this main nav.
-		$sub_nav_items = buddypress()->members->nav->get_secondary( array( 'parent_slug' => $slug ), false );
-
-		// Loop inside it to reset the link using BP Rewrites before updating it.
-		foreach ( $sub_nav_items as $sub_nav_item ) {
-			$sub_nav_item['link'] = bp_members_rewrites_get_nav_url(
-				array(
-					'rewrite_id'     => $rewrite_id,
-					'item_component' => $slug,
-					'item_action'    => $sub_nav_item['slug'],
-				)
-			);
-
-			// Update the secondary nav item.
-			buddypress()->members->nav->edit_nav( $sub_nav_item, $sub_nav_item['slug'], $slug );
-		}
+		// Update the secondary nav items.
+		reset_secondary_nav( $slug, $rewrite_id );
 	}
 
 	/**
@@ -141,7 +127,12 @@ class Messages_Component extends \BP_Messages_Component {
 				);
 
 				if ( $root_nav_parent !== $item_nav['parent'] && isset( $viewes_slugs[ $item_nav_id ] ) ) {
-					$url_params['item_action'] = $viewes_slugs[ $item_nav_id ];
+					$sub_nav_rewrite_id        = sprintf(
+						'%1$s_%2$s',
+						$rewrite_id,
+						str_replace( '-', '_', $viewes_slugs[ $item_nav_id ] )
+					);
+					$url_params['item_action'] = bp_rewrites_get_slug( 'members', $sub_nav_rewrite_id, $viewes_slugs[ $item_nav_id ] );
 				}
 
 				$wp_admin_nav[ $key_item_nav ]['href'] = bp_members_rewrites_get_nav_url( $url_params );

--- a/src/bp-notifications/classes/class-notifications-component.php
+++ b/src/bp-notifications/classes/class-notifications-component.php
@@ -70,22 +70,8 @@ class Notifications_Component extends \BP_Notifications_Component {
 		// Update the primary nav item.
 		buddypress()->members->nav->edit_nav( $main_nav, $slug );
 
-		// Get the sub nav items for this main nav.
-		$sub_nav_items = buddypress()->members->nav->get_secondary( array( 'parent_slug' => $slug ), false );
-
-		// Loop inside it to reset the link using BP Rewrites before updating it.
-		foreach ( $sub_nav_items as $sub_nav_item ) {
-			$sub_nav_item['link'] = bp_members_rewrites_get_nav_url(
-				array(
-					'rewrite_id'     => $rewrite_id,
-					'item_component' => $slug,
-					'item_action'    => $sub_nav_item['slug'],
-				)
-			);
-
-			// Update the secondary nav item.
-			buddypress()->members->nav->edit_nav( $sub_nav_item, $sub_nav_item['slug'], $slug );
-		}
+		// Update the secondary nav items.
+		reset_secondary_nav( $slug, $rewrite_id );
 	}
 
 	/**
@@ -138,7 +124,12 @@ class Notifications_Component extends \BP_Notifications_Component {
 				);
 
 				if ( $root_nav_parent !== $item_nav['parent'] && isset( $viewes_slugs[ $item_nav_id ] ) ) {
-					$url_params['item_action'] = $viewes_slugs[ $item_nav_id ];
+					$sub_nav_rewrite_id        = sprintf(
+						'%1$s_%2$s',
+						$rewrite_id,
+						str_replace( '-', '_', $viewes_slugs[ $item_nav_id ] )
+					);
+					$url_params['item_action'] = bp_rewrites_get_slug( 'members', $sub_nav_rewrite_id, $viewes_slugs[ $item_nav_id ] );
 				}
 
 				$wp_admin_nav[ $key_item_nav ]['href'] = bp_members_rewrites_get_nav_url( $url_params );

--- a/src/bp-settings/classes/class-settings-component.php
+++ b/src/bp-settings/classes/class-settings-component.php
@@ -97,22 +97,8 @@ class Settings_Component extends \BP_Settings_Component {
 		// Update the primary nav item.
 		buddypress()->members->nav->edit_nav( $main_nav, $slug );
 
-		// Get the sub nav items for this main nav.
-		$sub_nav_items = buddypress()->members->nav->get_secondary( array( 'parent_slug' => $slug ), false );
-
-		// Loop inside it to reset the link using BP Rewrites before updating it.
-		foreach ( $sub_nav_items as $sub_nav_item ) {
-			$sub_nav_item['link'] = bp_members_rewrites_get_nav_url(
-				array(
-					'rewrite_id'     => $rewrite_id,
-					'item_component' => $slug,
-					'item_action'    => $sub_nav_item['slug'],
-				)
-			);
-
-			// Update the secondary nav item.
-			buddypress()->members->nav->edit_nav( $sub_nav_item, $sub_nav_item['slug'], $slug );
-		}
+		// Update the secondary nav items.
+		reset_secondary_nav( $slug, $rewrite_id );
 	}
 
 	/**
@@ -169,7 +155,12 @@ class Settings_Component extends \BP_Settings_Component {
 				);
 
 				if ( $root_nav_parent !== $item_nav['parent'] && isset( $viewes_slugs[ $item_nav_id ] ) ) {
-					$url_params['item_action'] = $viewes_slugs[ $item_nav_id ];
+					$sub_nav_rewrite_id        = sprintf(
+						'%1$s_%2$s',
+						$rewrite_id,
+						str_replace( '-', '_', $viewes_slugs[ $item_nav_id ] )
+					);
+					$url_params['item_action'] = bp_rewrites_get_slug( 'members', $sub_nav_rewrite_id, $viewes_slugs[ $item_nav_id ] );
 				}
 
 				$wp_admin_nav[ $key_item_nav ]['href'] = bp_members_rewrites_get_nav_url( $url_params );

--- a/src/bp-templates/bp-nouveau.php
+++ b/src/bp-templates/bp-nouveau.php
@@ -168,6 +168,72 @@ function bp_nouveau_get_activity_directory_nav_items( $nav_items = array() ) {
 add_action( 'bp_nouveau_get_activity_directory_nav_items', __NAMESPACE__ . '\bp_nouveau_get_activity_directory_nav_items', 1, 1 );
 
 /**
+ * `bp_nouveau_get_nav_scope()` needs to be edited to stop using the nav slug.
+ *
+ * @since ?.0.0
+ *
+ * @param array $attributes The field attributes.
+ * @return array The field attributes.
+ */
+function bp_nouveau_reset_nav_scope( $attributes = array() ) {
+	if ( isset( $attributes['data-bp-user-scope'] ) ) {
+		$scoped_rewrite_id = '';
+		$current_component = \bp_current_component();
+
+		if ( $current_component ) {
+			$rewrite_id = bp_rewrites_get_custom_slug_rewrite_id( 'members', $attributes['data-bp-user-scope'], $current_component );
+
+			if ( $rewrite_id ) {
+				$attributes['data-bp-user-scope'] = str_replace(
+					array( 'bp_member_' . $current_component . '_', '_' ),
+					array( '', '-' ),
+					$rewrite_id
+				);
+			}
+		}
+	}
+
+	return $attributes;
+}
+add_filter( 'bp_get_form_field_attributes', __NAMESPACE__ . '\bp_nouveau_reset_nav_scope', 1, 1 );
+
+/**
+ * `bp_nouveau_get_nav_classes()` needs to be edited to stop using the nav slug.
+ *
+ * @since ?.0.0
+ *
+ * @param string $classes            A space separated list of classes.
+ * @param array  $arr_classes        The list of classes.
+ * @param array  $nav_item           The current nav item object.
+ * @param string $current_object_nav The current nav in use.
+ * @return string A space separated list of classes.
+ */
+function bp_nouveau_reset_nav_classes( $classes = '', $arr_classes = array(), $nav_item = array(), $current_object_nav = '' ) {
+	$current_rewrite_id = '';
+
+	if ( isset( $nav_item['rewrite_id'] ) && ! in_array( 'current', $arr_classes, true ) ) {
+		$current_component = \bp_current_component();
+		$current_action    = \bp_current_action();
+
+		if ( 'personal' === $current_object_nav ) {
+			$current_rewrite_id = 'bp_member_' . $current_component;
+
+			if ( $current_action ) {
+				$current_rewrite_id .= '_' . str_replace( '-', '_', $current_action );
+			}
+
+			if ( $nav_item['rewrite_id'] === $current_rewrite_id ) {
+				$arr_classes = array_merge( $arr_classes, array( 'current', 'selected' ) );
+				$classes     = join( ' ', $arr_classes );
+			}
+		}
+	}
+
+	return $classes;
+}
+add_filter( 'bp_nouveau_get_classes', __NAMESPACE__ . '\bp_nouveau_reset_nav_classes', 1, 4 );
+
+/**
  * `\bp_nouveau_get_blogs_directory_nav_items()` needs to use BP Rewrites to built the nav item URLs.
  *
  * @since ?.0.0

--- a/src/bp-xprofile/bp-xprofile-rewrites.php
+++ b/src/bp-xprofile/bp-xprofile-rewrites.php
@@ -33,7 +33,7 @@ function bp_xprofile_rewrites_get_edit_url( $url = '', $field_group_id = 0 ) {
 			'component_id'                 => 'members',
 			'single_item'                  => bp_rewrites_get_member_slug( \bp_displayed_user_id() ),
 			'single_item_component'        => bp_rewrites_get_slug( 'members', 'bp_member_profile', bp_get_profile_slug() ),
-			'single_item_action'           => 'edit',
+			'single_item_action'           => bp_rewrites_get_slug( 'members', 'bp_member_profile_edit', 'edit' ),
 			'single_item_action_variables' => array( 'group', $field_group_id ),
 		)
 	);

--- a/src/bp-xprofile/bp-xprofile-template.php
+++ b/src/bp-xprofile/bp-xprofile-template.php
@@ -28,3 +28,49 @@ function bp_get_the_profile_group_edit_form_action( $url = '' ) {
 	return bp_xprofile_rewrites_get_edit_url( '', $group->id );
 }
 add_filter( 'bp_get_the_profile_group_edit_form_action', __NAMESPACE__ . '\bp_get_the_profile_group_edit_form_action', 1, 1 );
+
+/**
+ * Return the XProfile group tabs.
+ *
+ * @since ?.0.0
+ *
+ * @param array  $tabs       Array of tabs to display.
+ * @param array  $groups     Array of profile groups.
+ * @param string $group_name Name of the current group displayed.
+ * @return array             Array of tabs to display.
+ */
+function bp_get_profile_group_tabs( $tabs = array(), $groups = array(), $group_name = '' ) {
+	$profile_group_tabs = array();
+
+	if ( is_array( $groups ) && count( $groups ) ) {
+		foreach ( $groups as $group ) {
+			$selected = '';
+			if ( $group_name === $group->name ) {
+				$selected = ' class="current"';
+			}
+
+			// Skip if group has no fields.
+			if ( empty( $group->fields ) ) {
+				continue;
+			}
+
+			// Build the profile field group link, using the BP Rewrites API.
+			$link = bp_xprofile_rewrites_get_edit_url( '', $group->id );
+
+			// Add tab to end of tabs array.
+			$profile_group_tabs[] = sprintf(
+				'<li %1$s><a href="%2$s">%3$s</a></li>',
+				$selected,
+				esc_url( $link ),
+				esc_html( apply_filters( 'bp_get_the_profile_group_name', $group->name ) )
+			);
+		}
+	}
+
+	if ( $profile_group_tabs ) {
+		return $profile_group_tabs;
+	}
+
+	return $tabs;
+}
+add_filter( 'xprofile_filter_profile_group_tabs', __NAMESPACE__ . '\bp_get_profile_group_tabs', 1, 3 );


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
Use a specific Rewrite ID to allow Secondary nav slug customization.
This PR also makes sure `bp_get_profile_group_tabs()` uses the BP Rewrites API.
Fixes #20 

## How has this been tested?
This has been tested in BP 10.0.0-RC1, activating components one by one when adding secondary nav slug customization for the corresponding just activated component. It needs:
- a test when a custom user front page is used.
- Admin UI improvements. 

## Screenshots <!-- if applicable -->
![secondary-nav-custom-slugs](https://user-images.githubusercontent.com/1834524/149638204-9c06044a-e485-4e96-85a2-d22f711bfb4d.png)


## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
