### PR TITLE
Fix the activity heartbeat too early `bp_is_activity_directory()` use

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -458,6 +458,14 @@ function disable_buddypress_legacy_url_parser() {
 	 * @see `BP\Rewrites\bp_members_admin_bar_add_invitations_menu()`
 	 */
 	remove_action( 'bp_setup_admin_bar', 'bp_members_admin_bar_add_invitations_menu', 90 );
+
+	/*
+	 * This filter is causing a too early call to `bp_is_activity_directory()`
+	 *
+	 * More globally the Activity Heartbeat feature should be improved by putting the script
+	 * inside its own file.
+	 */
+	remove_filter( 'bp_core_get_js_dependencies', 'bp_activity_get_js_dependencies', 10, 1 );
 }
 add_action( 'bp_init', __NAMESPACE__ . '\disable_buddypress_legacy_url_parser', 1 );
 

--- a/inc/loader.php
+++ b/inc/loader.php
@@ -44,6 +44,7 @@ function includes( $plugin_dir = '' ) {
 		require $path . 'src/bp-activity/bp-activity-rewrites.php';
 		require $path . 'src/bp-activity/bp-activity-functions.php';
 		require $path . 'src/bp-activity/bp-activity-filters.php';
+		require $path . 'src/bp-activity/bp-activity-cssjs.php';
 
 		if ( bp_is_active( 'notifications' ) ) {
 			require $path . 'src/bp-activity/bp-activity-notifications.php';

--- a/src/bp-activity/bp-activity-cssjs.php
+++ b/src/bp-activity/bp-activity-cssjs.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Activity component CSS/JS
+ *
+ * @package buddypress\bp-activity
+ * @since 1.0.0
+ */
+
+namespace BP\Rewrites;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Enqueues the Heartbeat script if needed.
+ *
+ * @since ?.0.0
+ */
+function bp_activity_heartbeat_enqueue_script() {
+	if ( bp_activity_do_heartbeat() ) {
+		wp_enqueue_script( 'heartbeat' );
+	}
+}
+add_action( 'bp_actions', __NAMESPACE__ . '\bp_activity_heartbeat_enqueue_script' );


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
Makes sure BuddyPress is not using `bp_is_activity_directory()` too early to check whether it should add the `heartbeat` dependency. This bug happened since 10.0 when using a theme supporting block templates.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
