### PR TITLE
Fix `bpRewritesUI` function call when `readyState` is not `loading`.

### DIFF
--- a/src/bp-core/admin/js/rewrites-ui.js
+++ b/src/bp-core/admin/js/rewrites-ui.js
@@ -25,6 +25,6 @@
 	if ( 'loading' === document.readyState ) {
 		document.addEventListener( 'DOMContentLoaded', bpRewritesUI );
 	} else {
-		bpRewritesUI;
+		bpRewritesUI();
 	}
 } )();


### PR DESCRIPTION
`bpRewritesUI` function call doesn't work when `document.readyState` is not `loading.` We should call function properly.