### PR TITLE
Anticipate WP 6.0 changes about the `$wp->request` global

### DIFF
--- a/src/bp-core/bp-core-template-loader.php
+++ b/src/bp-core/bp-core-template-loader.php
@@ -83,18 +83,7 @@ function bp_reset_query( $bp_request = '', \WP_Query $query = null ) {
 	}
 
 	// Temporarly override it.
-	if ( isset( $wp->request ) ) {
-		$_SERVER['REQUEST_URI'] = str_replace( $wp->request, $bp_request, $reset_server_request_uri );
-
-		// Reparse request.
-		$wp->parse_request();
-
-		// Reparse query.
-		bp_remove_all_filters( 'parse_query' );
-		$query->parse_query( $wp->query_vars );
-		bp_restore_all_filters( 'parse_query' );
-
-	} elseif ( isset( $bp->ajax ) ) {
+	if ( isset( $bp->ajax ) ) {
 		$_SERVER['REQUEST_URI'] = $bp_request;
 
 		if ( bp_has_pretty_urls() ) {
@@ -122,6 +111,17 @@ function bp_reset_query( $bp_request = '', \WP_Query $query = null ) {
 		 * This should be `remove_action( 'parse_query', 'bp_parse_query', 2 );` in BP Core.
 		 */
 		remove_action( 'parse_query', __NAMESPACE__ . '\bp_parse_query', 2 );
+
+	} elseif ( isset( $wp->request ) ) {
+		$_SERVER['REQUEST_URI'] = str_replace( $wp->request, $bp_request, $reset_server_request_uri );
+
+		// Reparse request.
+		$wp->parse_request();
+
+		// Reparse query.
+		bp_remove_all_filters( 'parse_query' );
+		$query->parse_query( $wp->query_vars );
+		bp_restore_all_filters( 'parse_query' );
 	}
 
 	// Restore request uri.


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
So far, this property was not set during Ajax calls. It now has been improved in WordPress trunk (6.0). To be sure Ajax is using the BP Rewrites API, we need to inverse the order of the statement inside the `bp_reset_query()` function. First check if the query is done via Ajax, then check if the site admin defined the constant to set root profiles.

## How has this been tested?
Fixing the issue and checking Ajax requests are parsed the right way in WP 6.0 & earlier versions.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
