### PR TITLE
Make sure BP Rewrites loads when BuddyPress is network activated

### DIFF
--- a/class-bp-rewrites.php
+++ b/class-bp-rewrites.php
@@ -70,7 +70,7 @@ final class BP_Rewrites {
 		$sitewide_plugins     = (array) get_site_option( 'active_sitewide_plugins', array() );
 
 		if ( $sitewide_plugins ) {
-			$is_buddypress_active = in_array( $bp_plugin_basename, $sitewide_plugins, true );
+			$is_buddypress_active = isset( $sitewide_plugins[ $bp_plugin_basename ] );
 		}
 
 		if ( ! $is_buddypress_active ) {


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
https://github.com/buddypress/bp-rewrites/commit/30daf9986e2af1c49f0d7c45c49ef17b2bc62702 introduced a regression for multisite configs when BuddyPress is network activated. Reason is the option to store sitewide active plugins uses plugin basename as keys where the one to store active plugins do not.

Fixes #32

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
