### PR TITLE
Avoid a fatar error when trying to access to a BP Core Nav too early

### DIFF
--- a/src/bp-core/classes/class-core-nav-compat.php
+++ b/src/bp-core/classes/class-core-nav-compat.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * BP Rewrites Core Component.
+ *
+ * @package bp-rewrites\src\bp-core\classes
+ * @since 1.0.0
+ */
+
+namespace BP\Rewrites;
+
+/**
+ * BP Core Nav Backcompat class.
+ *
+ * @since 1.0.0
+ */
+class Core_Nav_Compat {
+	/**
+	 * An array containing nav items created too early.
+	 *
+	 * @since 1.0.0
+	 * @var array
+	 */
+	public $nav = array();
+
+	/**
+	 * Hooks to `bp_parse_query` before `bp_setup_nav` to output a doing it wrong message.
+	 *
+	 * @since 1.0.0
+	 */
+	public function __construct() {
+		add_action( 'bp_parse_query', array( $this, 'doing_it_wrong' ), 11 );
+	}
+
+	/**
+	 * Outputs a doing it wrong message.
+	 *
+	 * @since 1.0.0
+	 */
+	public function doing_it_wrong() {
+		$nav_item_slugs = wp_list_pluck( $this->nav, 'slug' );
+
+		_doing_it_wrong(
+			'BuddyPress Members Nav',
+			sprintf(
+				/* Translators: 1: the list of nav items that were not added. */
+				esc_html__( 'Please wait for the `bp_setup_nav` hook to be fired before trying to create a nav or a subnav item. The following nav item slugs were not created: %s.', 'bp-rewrites' ),
+				'<strong style="color: red">' . implode( ', ', array_map( 'esc_html', $nav_item_slugs ) ) . '</strong>'
+			),
+			'BP Rewrites 1.0.0'
+		);
+	}
+
+	/**
+	 * Adds a new nav item.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $args The nav item's arguments.
+	 */
+	public function add_nav( $args ) {
+		$this->nav[] = (object) $args;
+	}
+}

--- a/src/bp-members/classes/class-members-component.php
+++ b/src/bp-members/classes/class-members-component.php
@@ -24,6 +24,34 @@ class Members_Component extends \BP_Members_Component {
 	}
 
 	/**
+	 * Magic getter.
+	 *
+	 * This exists specifically to avoid a fatal error when a plugin tries to create
+	 * a BP Nav Item too early.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key The name of the property.
+	 * @return null|BP\Rewrites\Core_Nav_Compat
+	 */
+	public function __get( $key = '' ) {
+		$retval = null;
+
+		if ( 'nav' === $key && ! did_action( 'bp_parse_query' ) ) {
+			$core_path = trailingslashit( plugin_dir_path( dirname( dirname( __FILE__ ) ) ) ) . 'bp-core/';
+			require $core_path . 'classes/class-core-nav-compat.php';
+
+			$retval = new Core_Nav_Compat();
+		}
+
+		if ( isset( $this->{$key} ) ) {
+			$retval = $this->{$key};
+		}
+
+		return $retval;
+	}
+
+	/**
 	 * Set up additional globals for the component.
 	 *
 	 * NB: Setting the displayed user as well as the BP Members Nav at this stage in

--- a/src/bp-members/classes/class-members-component.php
+++ b/src/bp-members/classes/class-members-component.php
@@ -37,15 +37,14 @@ class Members_Component extends \BP_Members_Component {
 	public function __get( $key = '' ) {
 		$retval = null;
 
-		if ( 'nav' === $key && ! did_action( 'bp_parse_query' ) ) {
-			$core_path = trailingslashit( plugin_dir_path( dirname( dirname( __FILE__ ) ) ) ) . 'bp-core/';
-			require $core_path . 'classes/class-core-nav-compat.php';
-
-			$retval = new Core_Nav_Compat();
-		}
-
 		if ( isset( $this->{$key} ) ) {
 			$retval = $this->{$key};
+		} elseif ( 'nav' === $key && ! did_action( 'bp_parse_query' ) ) {
+			$core_path = trailingslashit( plugin_dir_path( dirname( dirname( __FILE__ ) ) ) ) . 'bp-core/';
+			require_once $core_path . 'classes/class-core-nav-compat.php';
+
+			$retval    = new Core_Nav_Compat();
+			$this->nav = $retval;
 		}
 
 		return $retval;


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
Displays a doing it wrong message including the list of Nav/SubNav items that were not created.

Fixes #33

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
