### PR TITLE
Comply with WP.org plugins team review

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -416,8 +416,9 @@ function is_login_page() {
 
 	if ( isset( $GLOBALS['pagenow'] ) && ( false !== strpos( $GLOBALS['pagenow'], 'wp-login.php' ) ) ) {
 		$is_login = true;
-	} elseif ( isset( $_SERVER['SCRIPT_NAME'] ) && false !== strpos( $_SERVER['SCRIPT_NAME'], 'wp-login.php' ) ) { // phpcs:ignore
-		$is_login = true;
+	} elseif ( isset( $_SERVER['SCRIPT_NAME'] ) ) {
+		$script_name = esc_url_raw( wp_unslash( $_SERVER['SCRIPT_NAME'] ) );
+		$is_login    = false !== strpos( $script_name, 'wp-login.php' );
 	}
 
 	return $is_login;

--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -61,7 +61,7 @@ function bp_core_get_from_uri( $bp_global = array() ) {
 
 		// calculate the BuddyPress URI.
 	} elseif ( isset( $_SERVER['REQUEST_URI'] ) ) {
-		$requested_uri = esc_url( wp_unslash( $_SERVER['REQUEST_URI'] ) ); // phpcs:ignore
+		$requested_uri = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
 
 		/**
 		 * Filters the BuddyPress global URI path.

--- a/src/bp-core/bp-core-template-loader.php
+++ b/src/bp-core/bp-core-template-loader.php
@@ -79,7 +79,7 @@ function bp_reset_query( $bp_request = '', \WP_Query $query = null ) {
 	// Back up request uri.
 	$reset_server_request_uri = '';
 	if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-		$reset_server_request_uri = wp_unslash( $_SERVER['REQUEST_URI'] ); // phpcs:ignore
+		$reset_server_request_uri = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
 	}
 
 	// Temporarly override it.

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -25,8 +25,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return mixed            The BuddyPress global value set using the BP Legacy URL parser.
  */
 function _was_called_too_early( $function, $bp_global ) {
-	$retval   = null;
-	$request  = wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ); // phpcs:ignore
+	$retval      = null;
+	$request_uri = '';
+	if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+		$request_uri = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+	}
+
+	$request  = wp_parse_url( $request_uri, PHP_URL_PATH );
 	$is_admin = ( false !== strpos( $request, '/wp-admin' ) || is_admin() ) && ! wp_doing_ajax();
 
 	// The BP REST API needs more work.

--- a/src/bp-core/classes/class-core-component.php
+++ b/src/bp-core/classes/class-core-component.php
@@ -18,14 +18,17 @@ class Core_Component extends \BP_Core {
 	/**
 	 * Parse the WP_Query and eventually display the component's directory or single item.
 	 *
+	 * Search doesn't have an associated page, so we check for it separately.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param WP_Query $query Required. See BP_Component::parse_query() for
 	 *                        description.
 	 */
 	public function parse_query( $query ) {
-		// Search doesn't have an associated page, so we check for it separately.
-		if ( isset( $_POST['search-terms'] ) && $query->get( 'pagename' ) === bp_get_search_slug() ) { // phpcs:ignore
+		// phpcs:disable WordPress.Security.NonceVerification
+		if ( isset( $_POST['search-terms'] ) && $query->get( 'pagename' ) === bp_get_search_slug() ) {
+			// phpcs:enable WordPress.Security.NonceVerification
 			buddypress()->current_component = bp_get_search_slug();
 		}
 

--- a/src/bp-groups/actions/create.php
+++ b/src/bp-groups/actions/create.php
@@ -112,11 +112,9 @@ function groups_action_create_group() {
 				$new_group_id = $bp->groups->new_group_id;
 			}
 
-			// phpcs:disable WordPress.Security.ValidatedSanitizedInput
-			$new_group_name = wp_unslash( $_POST['group-name'] );
-			$new_group_slug = sanitize_title( esc_attr( $new_group_name ) );
-			$new_group_desc = wp_unslash( $_POST['group-desc'] );
-			// phpcs:enable WordPress.Security.ValidatedSanitizedInput
+			$new_group_name = sanitize_text_field( wp_unslash( $_POST['group-name'] ) );
+			$new_group_slug = sanitize_title( $new_group_name );
+			$new_group_desc = sanitize_textarea_field( wp_unslash( $_POST['group-desc'] ) );
 
 			$bp->groups->new_group_id = groups_create_group(
 				array(
@@ -143,15 +141,12 @@ function groups_action_create_group() {
 				$group_enable_forum = 0;
 			}
 
-			// phpcs:disable WordPress.Security.ValidatedSanitizedInput
 			if ( isset( $_POST['group-status'] ) ) {
-				if ( 'private' === wp_unslash( $_POST['group-status'] ) ) {
-					$group_status = 'private';
-				} elseif ( 'hidden' === wp_unslash( $_POST['group-status'] ) ) {
-					$group_status = 'hidden';
+				$posted_group_status = sanitize_text_field( wp_unslash( $_POST['group-status'] ) );
+				if ( 'private' === $posted_group_status || 'hidden' === $posted_group_status ) {
+					$group_status = $posted_group_status;
 				}
 			}
-			// phpcs:enable WordPress.Security.ValidatedSanitizedInput
 
 			$bp->groups->new_group_id = groups_create_group(
 				array(
@@ -362,13 +357,11 @@ function groups_action_create_group() {
 				'object'        => 'group',
 				'avatar_dir'    => 'group-avatars',
 				'item_id'       => $bp->groups->current_group->id,
-				// phpcs:disable WordPress.Security.ValidatedSanitizedInput
-				'original_file' => wp_unslash( $_POST['image_src'] ),
-				'crop_x'        => wp_unslash( $_POST['x'] ),
-				'crop_y'        => wp_unslash( $_POST['y'] ),
-				'crop_w'        => wp_unslash( $_POST['w'] ),
-				'crop_h'        => wp_unslash( $_POST['h'] ),
-				// phpcs:enable WordPress.Security.ValidatedSanitizedInput
+				'original_file' => esc_url_raw( wp_unslash( $_POST['image_src'] ) ),
+				'crop_x'        => ! isset( $_POST['x'] ) ? 0 : sanitize_text_field( wp_unslash( $_POST['x'] ) ),
+				'crop_y'        => ! isset( $_POST['y'] ) ? 0 : sanitize_text_field( wp_unslash( $_POST['y'] ) ),
+				'crop_w'        => ! isset( $_POST['w'] ) ? bp_core_avatar_full_width() : sanitize_text_field( wp_unslash( $_POST['w'] ) ),
+				'crop_h'        => ! isset( $_POST['h'] ) ? bp_core_avatar_full_height() : sanitize_text_field( wp_unslash( $_POST['h'] ) ),
 			);
 
 			$cropped_avatar = bp_core_avatar_handle_crop( $args, 'array' );

--- a/src/bp-groups/classes/class-bp-group-extension.php
+++ b/src/bp-groups/classes/class-bp-group-extension.php
@@ -523,8 +523,17 @@ if ( ! class_exists( 'BP_Group_Extension', false ) ) :
 			}
 
 			// On the admin, get the group id out of the $_GET params.
-			if ( empty( $group_id ) && is_admin() && ( isset( $_GET['page'] ) && ( 'bp-groups' === $_GET['page'] ) ) && ! empty( $_GET['gid'] ) ) { // phpcs:ignore
-				$group_id = (int) $_GET['gid']; // phpcs:ignore
+			if ( empty( $group_id ) && is_admin() ) {
+				// phpcs:disable WordPress.Security.NonceVerification
+				$admin_page = '';
+				if ( isset( $_GET['page'] ) ) {
+					$admin_page = sanitize_text_field( wp_unslash( $_GET['page'] ) );
+				}
+
+				if ( 'bp-groups' === $admin_page && isset( $_GET['gid'] ) ) {
+					$group_id = (int) sanitize_text_field( wp_unslash( $_GET['gid'] ) );
+				}
+				// phpcs:enable WordPress.Security.NonceVerification
 			}
 
 			/*
@@ -1250,7 +1259,7 @@ if ( ! class_exists( 'BP_Group_Extension', false ) ) :
 			add_action( 'bp_groups_admin_meta_box_content_' . $this->slug, array( $this, 'call_admin_screen' ) );
 
 			// Initialize the metabox.
-			add_action( 'bp_groups_admin_meta_boxes', array( $this, '_meta_box_display_callback' ) );
+			add_action( 'bp_groups_admin_meta_boxes', array( $this, 'meta_box_display_callback' ) );
 
 			// Catch the metabox save.
 			add_action( 'bp_group_admin_edit_after', array( $this, 'call_admin_screen_save' ), 10 );
@@ -1281,9 +1290,15 @@ if ( ! class_exists( 'BP_Group_Extension', false ) ) :
 		 *
 		 * @since 1.7.0
 		 */
-		public function _meta_box_display_callback() { // phpcs:ignore
-			$group_id = isset( $_GET['gid'] ) ? (int) $_GET['gid'] : 0; // phpcs:ignore
-			$screen   = $this->screens['admin'];
+		public function meta_box_display_callback() {
+			// phpcs:disable WordPress.Security.NonceVerification
+			$group_id = 0;
+			if ( isset( $_GET['gid'] ) ) {
+				$group_id = (int) sanitize_text_field( wp_unslash( $_GET['gid'] ) );
+			}
+			// phpcs:enable WordPress.Security.NonceVerification
+
+			$screen = $this->screens['admin'];
 
 			$extension_slug = $this->slug;
 			$callback       = function () use ( $extension_slug, $group_id ) {

--- a/src/bp-groups/classes/class-bp-group-extension.php
+++ b/src/bp-groups/classes/class-bp-group-extension.php
@@ -549,9 +549,11 @@ if ( ! class_exists( 'BP_Group_Extension', false ) ) :
 			 * $_POST array
 			 * @todo Figure out why this is happening during group creation.
 			 */
-			if ( empty( $group_id ) && isset( $_POST['group_id'] ) ) { // phpcs:ignore
-				$group_id = (int) $_POST['group_id']; // phpcs:ignore
+			// phpcs:disable WordPress.Security.NonceVerification
+			if ( empty( $group_id ) && isset( $_POST['group_id'] ) ) {
+				$group_id = (int) sanitize_text_field( wp_unslash( $_POST['group_id'] ) );
 			}
+			// phpcs:enable WordPress.Security.NonceVerification
 
 			return $group_id;
 		}
@@ -1138,9 +1140,11 @@ if ( ! class_exists( 'BP_Group_Extension', false ) ) :
 		 * @since 1.8.0
 		 */
 		public function call_edit_screen_save() {
-			if ( empty( $_POST ) ) { // phpcs:ignore
+			// phpcs:disable WordPress.Security.NonceVerification
+			if ( empty( $_POST ) ) {
 				return;
 			}
+			// phpcs:enable WordPress.Security.NonceVerification
 
 			/*
 			 * When DOING_AJAX, the POST global will be populated, but we


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
Sanitize, Escape, and Validate `$_POST`, `$_GET`, `$_REQUEST` and `$_FILE` calls in the plugin.

## How has this been tested?
Complying to the WP.org Plugins team review.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
