### PR TITLE
Make sure Members Invitations URLs are handled

### DIFF
--- a/src/bp-members/bp-members-adminbar.php
+++ b/src/bp-members/bp-members-adminbar.php
@@ -38,6 +38,7 @@ function bp_members_admin_bar_add_invitations_menu() {
 				'title'  => __( 'Invitations', 'bp-rewrites' ),
 				'href'   => bp_members_rewrites_get_nav_url(
 					array(
+						'user_id'        => $user_id,
 						'rewrite_id'     => $rewrite_id,
 						'item_component' => $parent_slug,
 					)
@@ -50,9 +51,10 @@ function bp_members_admin_bar_add_invitations_menu() {
 				'title'  => __( 'Pending Invites', 'bp-rewrites' ),
 				'href'   => bp_members_rewrites_get_nav_url(
 					array(
+						'user_id'        => $user_id,
 						'rewrite_id'     => $rewrite_id,
 						'item_component' => $parent_slug,
-						'item_action'    => 'list-invites',
+						'item_action'    => bp_rewrites_get_slug( 'members', 'bp_member_invitations_list_invites', 'list-invites' ),
 					)
 				),
 			),
@@ -65,9 +67,10 @@ function bp_members_admin_bar_add_invitations_menu() {
 				'title'  => __( 'Send Invites', 'bp-rewrites' ),
 				'href'   => bp_members_rewrites_get_nav_url(
 					array(
+						'user_id'        => $user_id,
 						'rewrite_id'     => $rewrite_id,
 						'item_component' => $parent_slug,
-						'item_action'    => 'send-invites',
+						'item_action'    => bp_rewrites_get_slug( 'members', 'bp_member_invitations_send_invites', 'send-invites' ),
 					)
 				),
 			);

--- a/src/bp-members/bp-members-invitations.php
+++ b/src/bp-members/bp-members-invitations.php
@@ -26,40 +26,27 @@ function bp_members_invitations_setup_nav() {
 		return;
 	}
 
-	$parent_slug = bp_get_members_invitations_slug();
-
 	// Get the main nav.
-	$main_nav = $bp->members->nav->get_primary( array( 'slug' => $parent_slug ), false );
+	$main_nav = $bp->members->nav->get_primary( array( 'slug' => bp_get_members_invitations_slug() ), false );
+	$main_nav = reset( $main_nav );
+	$slug     = $main_nav['slug'];
 
 	// Set the main nav `rewrite_id` property.
-	$main_nav['rewrite_id'] = sprintf( 'bp_member_%s', $parent_slug );
+	$main_nav['rewrite_id'] = sprintf( 'bp_member_%s', $slug );
 	$rewrite_id             = $main_nav['rewrite_id'];
 
 	// Reset the link using BP Rewrites.
 	$main_nav['link'] = bp_members_rewrites_get_nav_url(
 		array(
 			'rewrite_id'     => $rewrite_id,
-			'item_component' => $parent_slug,
+			'item_component' => $slug,
 		)
 	);
 
-	$bp->members->nav->edit_nav( $main_nav, $parent_slug );
+	// Update the primary nav item.
+	$bp->members->nav->edit_nav( $main_nav, $slug );
 
-	// Get the sub nav items for this main nav.
-	$sub_nav_items = $bp->members->nav->get_secondary( array( 'parent_slug' => $parent_slug ), false );
-
-	// Loop inside it to reset the link using BP Rewrites before updating it.
-	foreach ( $sub_nav_items as $sub_nav_item ) {
-		$sub_nav_item['link'] = bp_members_rewrites_get_nav_url(
-			array(
-				'rewrite_id'     => $rewrite_id,
-				'item_component' => $parent_slug,
-				'item_action'    => $sub_nav_item['slug'],
-			)
-		);
-
-		// Update the secondary nav item.
-		$bp->members->nav->edit_nav( $sub_nav_item, $sub_nav_item['slug'], $parent_slug );
-	}
+	// Update the secondary nav items.
+	reset_secondary_nav( $slug, $rewrite_id );
 }
 add_action( 'bp_setup_nav', __NAMESPACE__ . '\bp_members_invitations_setup_nav', 11 );


### PR DESCRIPTION
## Description
This [report on the Plugin's support forum](https://wordpress.org/support/topic/getting-a-fatal-error-12/) revealed the Members Invitations URLs unlike all the others were missed while adding rewrites support to Member's component sub navigation items.

## How has this been tested?
Fixing the issue.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
