### PR TITLE
Avoid displaying compat notices in some contexts

### DIFF
--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -31,9 +31,10 @@ function _was_called_too_early( $function, $bp_global ) {
 		$request_uri = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
 	}
 
+	// Into WP Admin & WP Login contexts BP Front end globals are not set.
 	$request  = wp_parse_url( $request_uri, PHP_URL_PATH );
 	$is_admin = ( false !== strpos( $request, '/wp-admin' ) || is_admin() ) && ! wp_doing_ajax();
-	$is_login =  false !== strpos( $request, '/wp-login.php' );
+	$is_login = false !== strpos( $request, '/wp-login.php' );
 
 	// The BP REST API needs more work.
 	$is_rest = false !== strpos( $request, '/' . rest_get_url_prefix() ) || ( defined( 'REST_REQUEST' ) && REST_REQUEST );

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -33,12 +33,16 @@ function _was_called_too_early( $function, $bp_global ) {
 
 	$request  = wp_parse_url( $request_uri, PHP_URL_PATH );
 	$is_admin = ( false !== strpos( $request, '/wp-admin' ) || is_admin() ) && ! wp_doing_ajax();
+	$is_login =  false !== strpos( $request, '/wp-login.php' );
 
 	// The BP REST API needs more work.
 	$is_rest = false !== strpos( $request, '/' . rest_get_url_prefix() ) || ( defined( 'REST_REQUEST' ) && REST_REQUEST );
 
+	// The XML RPC API needs more work.
+	$is_xmlrpc = defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST;
+
 	// `bp_parse_query` is not fired in WP Admin.
-	if ( did_action( 'bp_parse_query' ) || $is_admin || $is_rest ) {
+	if ( did_action( 'bp_parse_query' ) || $is_admin || $is_login || $is_rest || $is_xmlrpc ) {
 		return $retval;
 	}
 


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
Some plugins might try to get a BP Front end global in the WP Login context although they are not set! Using an xmlrpc request is also triggering notices. Just like the REST API, this needs more work to understand why front end globals are used there although a front end URL is not used.

See https://wordpress.org/support/topic/wp-login-php-issues/
See https://wordpress.org/support/topic/interfering-with-xmlrpc-php/

## How has this been tested?
Coding the fix

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
