### PR TITLE
Make sure the primary nav is set before resetting it

### DIFF
--- a/src/bp-activity/classes/class-activity-component.php
+++ b/src/bp-activity/classes/class-activity-component.php
@@ -92,14 +92,20 @@ class Activity_Component extends \BP_Activity_Component {
 		remove_action( 'bp_' . $this->id . '_setup_nav', array( $this, 'reset_nav' ), 20 );
 
 		// Get the main nav.
-		$main_nav = buddypress()->members->nav->get_primary( array( 'component_id' => $this->id ), false );
+		$activity_slug = bp_get_activity_slug();
+		$main_nav      = buddypress()->members->nav->get_primary( array( 'component_id' => $this->id ), false );
+
+		// Make sure the main navigation was built the right way.
+		if ( ! is_array( $main_nav ) || ! isset( $main_nav[ $activity_slug ] ) ) {
+			return;
+		}
 
 		// Set the main nav slug.
 		$main_nav = reset( $main_nav );
 		$slug     = $main_nav['slug'];
 
 		// Set the main nav `rewrite_id` property.
-		$rewrite_id             = sprintf( 'bp_member_%s', bp_get_activity_slug() );
+		$rewrite_id             = sprintf( 'bp_member_%s', $activity_slug );
 		$main_nav['rewrite_id'] = $rewrite_id;
 
 		// Reset the link using BP Rewrites.

--- a/src/bp-blogs/classes/class-blogs-component.php
+++ b/src/bp-blogs/classes/class-blogs-component.php
@@ -73,14 +73,20 @@ class Blogs_Component extends \BP_Blogs_Component {
 		remove_action( 'bp_' . $this->id . '_setup_nav', array( $this, 'reset_nav' ), 20 );
 
 		// Get the main nav.
-		$main_nav = buddypress()->members->nav->get_primary( array( 'component_id' => $this->id ), false );
+		$blogs_slug = bp_get_blogs_slug();
+		$main_nav   = buddypress()->members->nav->get_primary( array( 'component_id' => $this->id ), false );
+
+		// Make sure the main navigation was built the right way.
+		if ( ! is_array( $main_nav ) || ! isset( $main_nav[ $blogs_slug ] ) ) {
+			return;
+		}
 
 		// Set the main nav slug.
 		$main_nav = reset( $main_nav );
 		$slug     = $main_nav['slug'];
 
 		// Set the main nav `rewrite_id` property.
-		$rewrite_id             = sprintf( 'bp_member_%s', bp_get_blogs_slug() );
+		$rewrite_id             = sprintf( 'bp_member_%s', $blogs_slug );
 		$main_nav['rewrite_id'] = $rewrite_id;
 
 		// Reset the link using BP Rewrites.

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -43,7 +43,7 @@ function _was_called_too_early( $function, $bp_global ) {
 	$is_xmlrpc = defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST;
 
 	// `bp_parse_query` is not fired in WP Admin.
-	if ( did_action( 'bp_parse_query' ) || $is_admin || $is_login || $is_rest || $is_xmlrpc ) {
+	if ( did_action( 'bp_parse_query' ) || $is_admin || $is_login || $is_rest || $is_xmlrpc || wp_doing_cron() ) {
 		return $retval;
 	}
 

--- a/src/bp-core/classes/class-core-nav-compat.php
+++ b/src/bp-core/classes/class-core-nav-compat.php
@@ -98,6 +98,17 @@ class Core_Nav_Compat {
 	}
 
 	/**
+	 * Prevents a notice when the secondary nav wasn't set the right way.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return null
+	 */
+	public function get_secondary() {
+		return null;
+	}
+
+	/**
 	 * Restores problematic nav items.
 	 *
 	 * @since 1.0.0

--- a/src/bp-friends/classes/class-friends-component.php
+++ b/src/bp-friends/classes/class-friends-component.php
@@ -49,14 +49,20 @@ class Friends_Component extends \BP_Friends_Component {
 		remove_action( 'bp_' . $this->id . '_setup_nav', array( $this, 'reset_nav' ), 20 );
 
 		// Get the main nav.
-		$main_nav = buddypress()->members->nav->get_primary( array( 'component_id' => $this->id ), false );
+		$friends_slug = bp_get_friends_slug();
+		$main_nav     = buddypress()->members->nav->get_primary( array( 'component_id' => $this->id ), false );
+
+		// Make sure the main navigation was built the right way.
+		if ( ! is_array( $main_nav ) || ! isset( $main_nav[ $friends_slug ] ) ) {
+			return;
+		}
 
 		// Set the main nav slug.
 		$main_nav = reset( $main_nav );
 		$slug     = $main_nav['slug'];
 
 		// Set the main nav `rewrite_id` property.
-		$rewrite_id             = sprintf( 'bp_member_%s', bp_get_friends_slug() );
+		$rewrite_id             = sprintf( 'bp_member_%s', $friends_slug );
 		$main_nav['rewrite_id'] = $rewrite_id;
 
 		// Reset the link using BP Rewrites.

--- a/src/bp-groups/classes/class-groups-component.php
+++ b/src/bp-groups/classes/class-groups-component.php
@@ -335,14 +335,20 @@ class Groups_Component extends \BP_Groups_Component {
 		$bp = buddypress();
 
 		// Get the main nav.
-		$main_nav = $bp->members->nav->get_primary( array( 'component_id' => $this->id ), false );
+		$groups_slug = bp_get_groups_slug();
+		$main_nav    = $bp->members->nav->get_primary( array( 'component_id' => $this->id ), false );
+
+		// Make sure the main navigation was built the right way.
+		if ( ! is_array( $main_nav ) || ! isset( $main_nav[ $groups_slug ] ) ) {
+			return;
+		}
 
 		// Set the main nav slug.
 		$main_nav = reset( $main_nav );
 		$slug     = $main_nav['slug'];
 
 		// Set the main nav `rewrite_id` property.
-		$rewrite_id             = sprintf( 'bp_member_%s', bp_get_groups_slug() );
+		$rewrite_id             = sprintf( 'bp_member_%s', $groups_slug );
 		$main_nav['rewrite_id'] = $rewrite_id;
 
 		// Reset the link using BP Rewrites.

--- a/src/bp-members/classes/class-members-component.php
+++ b/src/bp-members/classes/class-members-component.php
@@ -233,20 +233,25 @@ class Members_Component extends \BP_Members_Component {
 		remove_action( 'bp_' . $this->id . '_setup_nav', array( $this, 'reset_nav' ), 20 );
 
 		// Get the main nav.
-		$main_nav = buddypress()->members->nav->get_primary( array( 'component_id' => $this->id ), false );
+		$members_slug = bp_get_profile_slug();
+		$main_nav     = buddypress()->members->nav->get_primary( array( 'component_id' => $this->id ), false );
+
+		if ( bp_displayed_user_has_front_template() ) {
+			$members_slug = 'front';
+		}
+
+		// Make sure the main navigation was built the right way.
+		if ( ! is_array( $main_nav ) || ! isset( $main_nav[ $members_slug ] ) ) {
+			return;
+		}
 
 		// Set the main nav slug.
 		$main_nav = reset( $main_nav );
 		$slug     = $main_nav['slug'];
 
-		if ( bp_get_profile_slug() === $slug ) {
-			$main_nav['rewrite_id'] = 'bp_member_profile';
-		} elseif ( 'front' === $slug ) {
-			$main_nav['rewrite_id'] = 'bp_member_front';
-		}
-
 		// Set the main nav `rewrite_id` property.
-		$rewrite_id = $main_nav['rewrite_id'];
+		$rewrite_id             = sprintf( 'bp_member_%s', $members_slug );
+		$main_nav['rewrite_id'] = $rewrite_id;
 
 		// Reset the link using BP Rewrites.
 		$main_nav['link'] = bp_members_rewrites_get_nav_url(

--- a/src/bp-messages/classes/class-messages-component.php
+++ b/src/bp-messages/classes/class-messages-component.php
@@ -49,14 +49,20 @@ class Messages_Component extends \BP_Messages_Component {
 		remove_action( 'bp_' . $this->id . '_setup_nav', array( $this, 'reset_nav' ), 20 );
 
 		// Get the main nav.
-		$main_nav = buddypress()->members->nav->get_primary( array( 'component_id' => $this->id ), false );
+		$messages_slug = bp_get_messages_slug();
+		$main_nav      = buddypress()->members->nav->get_primary( array( 'component_id' => $this->id ), false );
+
+		// Make sure the main navigation was built the right way.
+		if ( ! is_array( $main_nav ) || ! isset( $main_nav[ $messages_slug ] ) ) {
+			return;
+		}
 
 		// Set the main nav slug.
 		$main_nav = reset( $main_nav );
 		$slug     = $main_nav['slug'];
 
 		// Set the main nav `rewrite_id` property.
-		$rewrite_id             = sprintf( 'bp_member_%s', bp_get_messages_slug() );
+		$rewrite_id             = sprintf( 'bp_member_%s', $messages_slug );
 		$main_nav['rewrite_id'] = $rewrite_id;
 
 		// Reset the link using BP Rewrites.

--- a/src/bp-notifications/classes/class-notifications-component.php
+++ b/src/bp-notifications/classes/class-notifications-component.php
@@ -49,14 +49,20 @@ class Notifications_Component extends \BP_Notifications_Component {
 		remove_action( 'bp_' . $this->id . '_setup_nav', array( $this, 'reset_nav' ), 20 );
 
 		// Get the main nav.
-		$main_nav = buddypress()->members->nav->get_primary( array( 'component_id' => $this->id ), false );
+		$notifications_slug = bp_get_notifications_slug();
+		$main_nav           = buddypress()->members->nav->get_primary( array( 'component_id' => $this->id ), false );
+
+		// Make sure the main navigation was built the right way.
+		if ( ! is_array( $main_nav ) || ! isset( $main_nav[ $notifications_slug ] ) ) {
+			return;
+		}
 
 		// Set the main nav slug.
 		$main_nav = reset( $main_nav );
 		$slug     = $main_nav['slug'];
 
 		// Set the main nav`rewrite_id` property.
-		$rewrite_id             = sprintf( 'bp_member_%s', bp_get_notifications_slug() );
+		$rewrite_id             = sprintf( 'bp_member_%s', $notifications_slug );
 		$main_nav['rewrite_id'] = $rewrite_id;
 
 		// Reset the link using BP Rewrites.

--- a/src/bp-settings/classes/class-settings-component.php
+++ b/src/bp-settings/classes/class-settings-component.php
@@ -76,14 +76,20 @@ class Settings_Component extends \BP_Settings_Component {
 		remove_action( 'bp_' . $this->id . '_setup_nav', array( $this, 'reset_nav' ), 20 );
 
 		// Get the main nav.
-		$main_nav = buddypress()->members->nav->get_primary( array( 'component_id' => $this->id ), false );
+		$settings_slug = bp_get_settings_slug();
+		$main_nav      = buddypress()->members->nav->get_primary( array( 'component_id' => $this->id ), false );
+
+		// Make sure the main navigation was built the right way.
+		if ( ! is_array( $main_nav ) || ! isset( $main_nav[ $settings_slug ] ) ) {
+			return;
+		}
 
 		// Set the main nav slug.
 		$main_nav = reset( $main_nav );
 		$slug     = $main_nav['slug'];
 
 		// Set the main nav`rewrite_id` property.
-		$rewrite_id             = sprintf( 'bp_member_%s', bp_get_settings_slug() );
+		$rewrite_id             = sprintf( 'bp_member_%s', $settings_slug );
 		$main_nav['rewrite_id'] = $rewrite_id;
 
 		// Reset the link using BP Rewrites.

--- a/src/bp-xprofile/classes/class-xprofile-component.php
+++ b/src/bp-xprofile/classes/class-xprofile-component.php
@@ -72,7 +72,13 @@ class XProfile_Component extends \BP_XProfile_Component {
 		remove_action( 'bp_' . $this->id . '_setup_nav', array( $this, 'reset_nav' ), 20 );
 
 		// Get the main nav.
-		$main_nav = buddypress()->members->nav->get_primary( array( 'slug' => bp_get_profile_slug() ), false );
+		$xprofile_slug = bp_get_profile_slug();
+		$main_nav      = buddypress()->members->nav->get_primary( array( 'slug' => $xprofile_slug ), false );
+
+		// Make sure the main navigation was built the right way.
+		if ( ! is_array( $main_nav ) || ! isset( $main_nav[ $xprofile_slug ] ) ) {
+			return;
+		}
 
 		// Set the main nav slug.
 		$main_nav = reset( $main_nav );


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
The bug was revealed by this support topic on Plugin's WP page: https://wordpress.org/support/topic/fatal-error-with-wp-cron-php/. In WP Cron context, we shouldn't expect to have primary navigation items set and we should also remove "was called to early" notices.

## How has this been tested?
Fixing the bug

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
