### PR TITLE
Do not trigger "was called too early" notices when submitting comments

### DIFF
--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -32,7 +32,7 @@ function _was_called_too_early( $function, $bp_global ) {
 	}
 
 	// Into WP Admin & WP Login contexts BP Front end globals are not set.
-	$request  = wp_parse_url( $request_uri, PHP_URL_PATH );
+	$request         = wp_parse_url( $request_uri, PHP_URL_PATH );
 	$is_admin        = ( false !== strpos( $request, '/wp-admin' ) || is_admin() ) && ! wp_doing_ajax();
 	$is_login        = false !== strpos( $request, '/wp-login.php' );
 	$is_comment_post = false !== strpos( $request, '/wp-comments-post.php' );

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -33,8 +33,9 @@ function _was_called_too_early( $function, $bp_global ) {
 
 	// Into WP Admin & WP Login contexts BP Front end globals are not set.
 	$request  = wp_parse_url( $request_uri, PHP_URL_PATH );
-	$is_admin = ( false !== strpos( $request, '/wp-admin' ) || is_admin() ) && ! wp_doing_ajax();
-	$is_login = false !== strpos( $request, '/wp-login.php' );
+	$is_admin        = ( false !== strpos( $request, '/wp-admin' ) || is_admin() ) && ! wp_doing_ajax();
+	$is_login        = false !== strpos( $request, '/wp-login.php' );
+	$is_comment_post = false !== strpos( $request, '/wp-comments-post.php' );
 
 	// The BP REST API needs more work.
 	$is_rest = false !== strpos( $request, '/' . rest_get_url_prefix() ) || ( defined( 'REST_REQUEST' ) && REST_REQUEST );
@@ -43,7 +44,7 @@ function _was_called_too_early( $function, $bp_global ) {
 	$is_xmlrpc = defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST;
 
 	// `bp_parse_query` is not fired in WP Admin.
-	if ( did_action( 'bp_parse_query' ) || $is_admin || $is_login || $is_rest || $is_xmlrpc || wp_doing_cron() ) {
+	if ( did_action( 'bp_parse_query' ) || $is_admin || $is_login || $is_comment_post || $is_rest || $is_xmlrpc || wp_doing_cron() ) {
 		return $retval;
 	}
 


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
Make sure the "was called too early" notices are triggered when submitting comments

## How has this been tested?
Fixing the issue

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->