### PR TITLE
Bring BP Rewrites support to bbPress

### DIFF
--- a/inc/loader.php
+++ b/inc/loader.php
@@ -111,5 +111,10 @@ function includes( $plugin_dir = '' ) {
 		require $path . 'src/bp-core/admin/bp-core-admin-functions.php';
 		require $path . 'src/bp-core/admin/bp-core-admin-rewrites.php';
 	}
+
+	// Plugins.
+	if ( function_exists( 'bbpress' ) ) {
+		require $path . 'src/bp-plugins/bbpress.php';
+	}
 }
 add_action( '_bp_rewrites_includes', __NAMESPACE__ . '\includes', 1, 1 );

--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -287,7 +287,7 @@ function bp_get_group_views( $context = 'read' ) {
 		);
 
 		foreach ( $valid_custom_views as $key_view => $view ) {
-			if ( ! in_array( $view['rewrite_id'], $existing_rewrite_ids, true ) ) {
+			if ( ! isset( $view['rewrite_id'] ) || ! in_array( $view['rewrite_id'], $existing_rewrite_ids, true ) ) {
 				continue;
 			}
 

--- a/src/bp-plugins/bbpress.php
+++ b/src/bp-plugins/bbpress.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Required bbPress edits.
+ *
+ * @package buddypress\bp-plugins\bbpress
+ * @since 1.3.0
+ */
+
+namespace BP\Rewrites;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Let's override the way bbPress does to what it should.
+remove_action( 'bp_include', 'bbp_setup_buddypress', 10 );
+
+/**
+ * Override the main bbPress's BP Component class.
+ *
+ * @since 1.3.0
+ */
+function bbp_setup_buddypress() {
+	$bp = null;
+
+	if ( function_exists( 'buddypress' ) ) {
+		$bp = buddypress();
+	}
+
+	// Bail if in maintenance mode.
+	if ( ! $bp || $bp->maintenance_mode ) {
+		return;
+	}
+
+	// Include the BuddyPress Component.
+	require_once bbpress()->includes_dir . 'extend/buddypress/loader.php';
+	require_once plugin_dir_path( __FILE__ ) . 'bbpress/class-forums-component.php';
+
+	// Instantiate BuddyPress for bbPress and for BP Rewrites!
+	bbpress()->extend->buddypress = new Forums_Component();
+}
+add_action( 'bp_include', __NAMESPACE__ . '\bbp_setup_buddypress', 10 );
+
+/**
+ * Remove a problematic hook happening too early.
+ *
+ * @since 1.3.0
+ */
+function bbp_remove_hooks() {
+	remove_filter( 'bbp_get_user_id', 'bbp_filter_user_id', 10, 3 );
+}
+add_action( 'bbp_buddypress_loaded', __NAMESPACE__ . '\bbp_remove_hooks', 1, 1 );
+
+/**
+ * Restore the problematic hook so that it happens at a better time.
+ *
+ * @since 1.3.0
+ */
+function bbp_restore_hooks() {
+	add_filter( 'bbp_get_user_id', 'bbp_filter_user_id', 10, 3 );
+}
+add_action( 'bp_parse_query', __NAMESPACE__ . '\bbp_restore_hooks', 1, 1 );
+
+/**
+ * Should the forum tab be displayed for the current group?
+ *
+ * @since 1.3.0
+ *
+ * @return bool True to display the "Forum" tab. False otherwise.
+ */
+function bbp_show_group_tab() {
+	$retval = false;
+
+	if ( did_action( 'bp_parse_query' ) ) {
+		$group_id = (int) bp_get_current_group_id();
+
+		if ( ! $group_id && bp_get_new_group_id() ) {
+			$group_id = (int) bp_get_new_group_id();
+		}
+
+		$retval = bp_get_new_group_enable_forum() || groups_get_groupmeta( $group_id, 'forum_id' );
+	}
+
+	return (bool) $retval;
+}

--- a/src/bp-plugins/bbpress.php
+++ b/src/bp-plugins/bbpress.php
@@ -84,3 +84,41 @@ function bbp_show_group_tab() {
 
 	return (bool) $retval;
 }
+
+/**
+ * Returns the Group Forum slug.
+ *
+ * @since 1.3.0
+ *
+ * @return string The Group Forum slug.
+ */
+function bbp_get_group_forum_slug() {
+	$views = bp_get_group_views( 'read' );
+	$slug  = 'forum';
+
+	if ( isset( $views[ $slug ]['rewrite_id'] ) ) {
+		$view = $views[ $slug ];
+		$slug = bp_rewrites_get_slug( 'groups', $view['rewrite_id'], $slug );
+	}
+
+	return $slug;
+}
+
+/**
+ * Returns the Group Admin Forum slug.
+ *
+ * @since 1.3.0
+ *
+ * @return string The Group Admin Forum slug.
+ */
+function bbp_get_group_admin_forum_slug() {
+	$views = bp_get_group_views( 'manage' );
+	$slug  = 'forum';
+
+	if ( isset( $views[ $slug ]['rewrite_id'] ) ) {
+		$view = $views[ $slug ];
+		$slug = bp_rewrites_get_slug( 'groups', $view['rewrite_id'], $slug );
+	}
+
+	return $slug;
+}

--- a/src/bp-plugins/bbpress.php
+++ b/src/bp-plugins/bbpress.php
@@ -122,3 +122,51 @@ function bbp_get_group_admin_forum_slug() {
 
 	return $slug;
 }
+
+/**
+ * Make sure Activity format callback is available for groups.
+ *
+ * @since 1.3.0
+ */
+function bbp_register_activity_actions() {
+	$bp = buddypress();
+
+	// Group Forum topic.
+	bp_activity_set_action(
+		$bp->groups->id,
+		'bbp_topic_create',
+		esc_html__( 'New Group forum topic', 'bp-rewrites' ),
+		'bbp_format_activity_action_new_topic',
+		esc_html__( 'Topics', 'bp-rewrites' ),
+		array( 'group' )
+	);
+
+	// Group Forum reply.
+	bp_activity_set_action(
+		$bp->groups->id,
+		'bbp_reply_create',
+		esc_html__( 'New Group forum reply', 'bp-rewrites' ),
+		'bbp_format_activity_action_new_reply',
+		esc_html__( 'Replies', 'bp-rewrites' ),
+		array( 'group' )
+	);
+}
+add_action( 'bp_register_activity_actions', __NAMESPACE__ . '\bbp_register_activity_actions', 100 );
+
+/**
+ * Filters the action type being set for the Sitewide forum topics and replies.
+ *
+ * @since 1.3.0
+ *
+ * @param array  $args         Array of arguments for action type being set.
+ * @param string $component_id The name of the component.
+ * @return array Array of arguments for action type being set.
+ */
+function bbp_activity_set_action( $args = array(), $component_id = '' ) {
+	if ( 'bbpress' === $component_id ) {
+		$args['context'] = array_diff( $args['context'], array( 'group' ) );
+	}
+
+	return $args;
+}
+add_filter( 'bp_activity_set_action', __NAMESPACE__ . '\bbp_activity_set_action', 10, 2 );

--- a/src/bp-plugins/bbpress/class-forums-component.php
+++ b/src/bp-plugins/bbpress/class-forums-component.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * BP Rewrites Forums Component.
+ *
+ * @package bp-rewrites\src\bp-plugins\bbpress
+ * @since 1.3.0
+ */
+
+namespace BP\Rewrites;
+
+/**
+ * Main Forums Class.
+ *
+ * @since 1.3.0
+ */
+class Forums_Component extends \BBP_Forums_Component {
+	/**
+	 * Overrides parent::includes() to adapt the group extension
+	 * to BP Rewrites.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param array $includes An array containing the scripts to include.
+	 */
+	public function includes( $includes = array() ) {
+		parent::includes( $includes );
+
+		// BuddyPress Group Extension class.
+		if ( bbp_is_group_forums_active() && bp_is_active( 'groups' ) ) {
+			require_once plugin_dir_path( __FILE__ ) . 'class-forums-group-extension.php';
+		}
+	}
+
+	/**
+	 * Instantiate classes for BuddyPress integration
+	 *
+	 * @since 1.3.0
+	 */
+	public function setup_components() {
+		// Always load the members component.
+		bbpress()->extend->buddypress->members = new \BBP_BuddyPress_Members();
+
+		// Create new activity class.
+		if ( bp_is_active( 'activity' ) ) {
+			bbpress()->extend->buddypress->activity = new \BBP_BuddyPress_Activity();
+		}
+
+		// Register the group extension only if groups are active.
+		if ( bbp_is_group_forums_active() && bp_is_active( 'groups' ) ) {
+			bp_register_group_extension( 'BP\Rewrites\Forums_Group_Extension' );
+		}
+	}
+}

--- a/src/bp-plugins/bbpress/class-forums-group-extension.php
+++ b/src/bp-plugins/bbpress/class-forums-group-extension.php
@@ -304,6 +304,29 @@ class Forums_Group_Extension extends \BBP_Forums_Group_Extension {
 	}
 
 	/**
+	 * Overrides bbPress `post_link`, `page_link` & `post_type_link` filters.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param int    $post_id The post type ID.
+	 * @param string $url     The post type permalink.
+	 * @return string The post type permalink built usint BP Rewrites.
+	 */
+	public function maybe_map_permalink_to_group( $post_id, $url ) {
+		$post_type = get_post_type( $post_id );
+
+		if ( bbp_get_reply_post_type() === $post_type ) {
+			$url = $this->map_reply_permalink_to_group( $url, $post_id );
+		} elseif ( bbp_get_topic_post_type() === $post_type ) {
+			$url = $this->map_topic_permalink_to_group( $url, $post_id );
+		} elseif ( bbp_get_forum_post_type() === $post_type ) {
+			$url = $this->map_forum_permalink_to_group( $url, $post_id );
+		}
+
+		return $url;
+	}
+
+	/**
 	 * Setup the group forums class actions.
 	 *
 	 * PS: Too bad this one is private :(.

--- a/src/bp-plugins/bbpress/class-forums-group-extension.php
+++ b/src/bp-plugins/bbpress/class-forums-group-extension.php
@@ -170,6 +170,40 @@ class Forums_Group_Extension extends \BBP_Forums_Group_Extension {
 	}
 
 	/**
+	 * Map a topic permalink to its group forum using BP Rewrites.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param string $url      The Group Topic URL.
+	 * @param int    $topic_id The Group Topic ID.
+	 * @return string The Group Topic URL built using BP Rewrites.
+	 */
+	public function map_topic_permalink_to_group( $url, $topic_id ) {
+		$forum_id   = \bbp_get_topic_forum_id( $topic_id );
+		$topic_name = \get_post_field( 'post_name', $topic_id );
+		$group_ids  = \bbp_get_forum_group_ids( $forum_id );
+		$group_id   = reset( $group_ids );
+
+		if ( ! $group_id ) {
+			return $url;
+		}
+
+		$group = \bp_get_group( $group_id );
+		if ( ! isset( $group->id ) || (int) $group->id !== (int) $group_id ) {
+			return $url;
+		}
+
+		return bp_rewrites_get_url(
+			array(
+				'component_id'                 => 'groups',
+				'single_item'                  => $group->slug,
+				'single_item_action'           => bbp_get_group_forum_slug(),
+				'single_item_action_variables' => array( $this->topic_slug, $topic_name ),
+			)
+		);
+	}
+
+	/**
 	 * Setup the group forums class actions.
 	 *
 	 * PS: Too bad this one is private :(.

--- a/src/bp-plugins/bbpress/class-forums-group-extension.php
+++ b/src/bp-plugins/bbpress/class-forums-group-extension.php
@@ -97,7 +97,7 @@ class Forums_Group_Extension extends \BBP_Forums_Group_Extension {
 	}
 
 	/**
-	 * Redirect to the group forum screen
+	 * Redirect to the group forum topic page.
 	 *
 	 * @since 1.3.0
 	 *
@@ -120,6 +120,50 @@ class Forums_Group_Extension extends \BBP_Forums_Group_Extension {
 			);
 
 			$redirect_url .= $topic_hash;
+		}
+
+		return $redirect_url;
+	}
+
+	/**
+	 * Redirect to the group forum topic page.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param string $redirect_url The original redirect URL.
+	 * @param string $redirect_to  The value of the `redirect_to` query parameter.
+	 * @param int    $reply_id     The topic reply ID.
+	 * @return string The URL to redirect the user to, built using BP Rewrites.
+	 */
+	public function new_reply_redirect_to( $redirect_url = '', $redirect_to = '', $reply_id = 0 ) {
+
+		if ( bp_is_group() ) {
+			$topic_id       = bbp_get_reply_topic_id( $reply_id );
+			$topic          = bbp_get_topic( $topic_id );
+			$reply_position = bbp_get_reply_position( $reply_id, $topic_id );
+			$reply_page     = ceil( (int) $reply_position / (int) bbp_get_replies_per_page() );
+			$reply_hash     = '#post-' . $reply_id;
+			$reply_url_args = array(
+				'component_id'                 => 'groups',
+				'single_item'                  => \groups_get_current_group()->slug,
+				'single_item_action'           => bbp_get_group_forum_slug(),
+				'single_item_action_variables' => array( $this->topic_slug, $topic->post_name ),
+			);
+
+			// Don't include pagination if on first page.
+			if ( 1 >= $reply_page ) {
+				$redirect_url = bp_rewrites_get_url( $reply_url_args ) . $reply_hash;
+
+				// Include pagination.
+			} else {
+				$reply_url_args['single_item_action_variables'] = array( $this->topic_slug, $topic->post_name, bbp_get_paged_slug(), $reply_page );
+				$redirect_url                                   = bp_rewrites_get_url( $reply_url_args ) . $reply_hash;
+			}
+
+			// Add topic view query arg back to end if it is set.
+			if ( bbp_get_view_all() ) {
+				$redirect_url = bbp_add_view_all( $redirect_url );
+			}
 		}
 
 		return $redirect_url;

--- a/src/bp-plugins/bbpress/class-forums-group-extension.php
+++ b/src/bp-plugins/bbpress/class-forums-group-extension.php
@@ -244,7 +244,7 @@ class Forums_Group_Extension extends \BBP_Forums_Group_Extension {
 				'single_item_action'           => bbp_get_group_forum_slug(),
 				'single_item_action_variables' => array( $this->topic_slug, $topic_name ),
 			)
-		) . '#post-' . $topic_id;
+		);
 	}
 
 	/**
@@ -274,6 +274,33 @@ class Forums_Group_Extension extends \BBP_Forums_Group_Extension {
 				'single_item_action_variables' => array( $this->topic_slug, $topic_name ),
 			)
 		) . '#post-' . $reply_id;
+	}
+
+	/**
+	 * Map a reply edit permalink to its group forum using BP Rewrites.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param string $url      The Group Reply URL.
+	 * @param int    $reply_id The Group Reply ID.
+	 * @return string The Group Reply edit URL built using BP Rewrites.
+	 */
+	public function map_reply_edit_url_to_group( $url, $reply_id ) {
+		$forum_id = \bbp_get_reply_forum_id( $reply_id );
+		$group    = $this->get_group_for_forum( $forum_id );
+
+		if ( is_null( $group ) ) {
+			return $url;
+		}
+
+		return bp_rewrites_get_url(
+			array(
+				'component_id'                 => 'groups',
+				'single_item'                  => $group->slug,
+				'single_item_action'           => bbp_get_group_forum_slug(),
+				'single_item_action_variables' => array( $this->reply_slug, $reply_id, bbpress()->edit_id ),
+			)
+		);
 	}
 
 	/**

--- a/src/bp-plugins/bbpress/class-forums-group-extension.php
+++ b/src/bp-plugins/bbpress/class-forums-group-extension.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * BP Rewrites Forums Group Extension.
+ *
+ * @package bp-rewrites\src\bp-plugins\bbpress
+ * @since 1.3.0
+ */
+
+namespace BP\Rewrites;
+
+/**
+ * Forums Group Extension Class.
+ *
+ * @since 1.3.0
+ */
+class Forums_Group_Extension extends \BBP_Forums_Group_Extension {
+	/**
+	 * The bbPress plugin should migrate to the new BP Group Extension API.
+	 *
+	 * @see https://codex.buddypress.org/developer/group-extension-api/
+	 *
+	 * @since 1.3.0
+	 */
+	public function __construct() {
+		\BP_Group_Extension::init(
+			array(
+				'slug'              => 'forum',
+				'name'              => esc_html__( 'Forum', 'bbpress' ),
+				'nav_item_name'     => esc_html__( 'Forum', 'bbpress' ),
+				'visibility'        => 'public',
+				'nav_item_position' => 10,
+				'enable_nav_item'   => true,
+				'template_file'     => 'groups/single/plugins',
+				'display_hook'      => 'bp_template_content',
+				'screens'           => array(
+					'create' => array(
+						'position'             => 15,
+						'enabled'              => true,
+						'screen_callback'      => array( $this, 'create_screen' ),
+						'screen_save_callback' => array( $this, 'create_screen_save' ),
+					),
+					'edit'   => array(
+						'enabled'              => true,
+						'screen_callback'      => array( $this, 'edit_screen' ),
+						'screen_save_callback' => array( $this, 'edit_screen_save' ),
+					),
+				),
+				'show_tab'          => __NAMESPACE__ . '\bbp_show_group_tab',
+			)
+		);
+
+		// Forces the show tab callback to always be triggered.
+		$this->params['show_tab'] = 'noone';
+
+		$this->setup_actions();
+		$this->setup_filters();
+		$this->fully_loaded();
+	}
+
+	/**
+	 * Setup the group forums class actions.
+	 *
+	 * PS: Too bad this one is private :(.
+	 *
+	 * @since 1.3.0
+	 */
+	private function setup_actions() {
+
+		// Possibly redirect.
+		add_action( 'bbp_template_redirect', array( $this, 'redirect_canonical' ) );
+
+		// Remove group forum cap map when view is done.
+		add_action( 'bbp_after_group_forum_display', array( $this, 'remove_group_forum_meta_cap_map' ) );
+
+		// Validate group IDs when editing topics & replies.
+		add_action( 'bbp_edit_topic_pre_extras', array( $this, 'validate_topic_forum_id' ) );
+		add_action( 'bbp_edit_reply_pre_extras', array( $this, 'validate_reply_to_id' ) );
+
+		// Check if group-forum attributes should be changed.
+		add_action( 'groups_group_after_save', array( $this, 'update_group_forum' ) );
+
+		// bbPress needs to listen to BuddyPress group deletion.
+		add_action( 'groups_before_delete_group', array( $this, 'disconnect_forum_from_group' ) );
+
+		// Adds a bbPress meta-box to the new BuddyPress Group Admin UI.
+		add_action( 'bp_groups_admin_meta_boxes', array( $this, 'group_admin_ui_edit_screen' ) );
+
+		// Saves the bbPress options if they come from the BuddyPress Group Admin UI.
+		add_action( 'bp_group_admin_edit_after', array( $this, 'edit_screen_save' ) );
+
+		// Adds a hidden input value to the "Group Settings" page.
+		add_action( 'bp_before_group_settings_admin', array( $this, 'group_settings_hidden_field' ) );
+	}
+
+	/**
+	 * Setup the group forums class filters.
+	 *
+	 * PS: Too bad this one is private :(.
+	 *
+	 * @since 1.3.0
+	 */
+	private function setup_filters() {
+
+		// Group forum pagination.
+		add_filter( 'bbp_topic_pagination', array( $this, 'topic_pagination' ) );
+		add_filter( 'bbp_replies_pagination', array( $this, 'replies_pagination' ) );
+
+		// Tweak the redirect field.
+		add_filter( 'bbp_new_topic_redirect_to', array( $this, 'new_topic_redirect_to' ), 10, 3 );
+		add_filter( 'bbp_new_reply_redirect_to', array( $this, 'new_reply_redirect_to' ), 10, 3 );
+
+		// Map forum/topic/reply permalinks to their groups.
+		add_filter( 'bbp_get_forum_permalink', array( $this, 'map_forum_permalink_to_group' ), 10, 2 );
+		add_filter( 'bbp_get_topic_permalink', array( $this, 'map_topic_permalink_to_group' ), 10, 2 );
+		add_filter( 'bbp_get_reply_permalink', array( $this, 'map_reply_permalink_to_group' ), 10, 2 );
+
+		// Map reply edit links to their groups.
+		add_filter( 'bbp_get_reply_edit_url', array( $this, 'map_reply_edit_url_to_group' ), 10, 2 );
+
+		// Map assorted template function permalinks.
+		add_filter( 'post_link', array( $this, 'post_link' ), 10, 2 );
+		add_filter( 'page_link', array( $this, 'page_link' ), 10, 2 );
+		add_filter( 'post_type_link', array( $this, 'post_type_link' ), 10, 2 );
+
+		// Map group forum activity items to groups.
+		add_filter( 'bbp_before_record_activity_parse_args', array( $this, 'map_activity_to_group' ) );
+
+		// Only add these filters if inside a group forum.
+		if ( bp_is_single_item() && bp_is_group() && bp_is_current_action( $this->slug ) ) {
+
+			// Ensure bbp_is_single_forum() returns true on group forums.
+			add_filter( 'bbp_is_single_forum', array( $this, 'is_single_forum' ) );
+
+			// Ensure bbp_is_single_topic() returns true on group forum topics.
+			add_filter( 'bbp_is_single_topic', array( $this, 'is_single_topic' ) );
+
+			// Allow group member to view private/hidden forums.
+			add_filter( 'bbp_map_meta_caps', array( $this, 'map_group_forum_meta_caps' ), 10, 4 );
+
+			// Group member permissions to view the topic and reply forms.
+			add_filter( 'bbp_current_user_can_access_create_topic_form', array( $this, 'form_permissions' ) );
+			add_filter( 'bbp_current_user_can_access_create_reply_form', array( $this, 'form_permissions' ) );
+		}
+	}
+
+	/**
+	 * Allow the variables, actions, and filters to be modified by third party
+	 * plugins and themes.
+	 *
+	 * PS: Too bad this one is private :(.
+	 *
+	 * @since 1.3.0
+	 */
+	private function fully_loaded() {
+		do_action_ref_array( 'bbp_buddypress_groups_loaded', array( $this ) );
+	}
+}


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
bbPress is not compatible with BP Rewrites, mainly because it uses an outdated version of the BP Group Extension API. As this plugin is often use with BuddyPress, I believe we should make sure to include into BP Rewrites the fix and move this fix to the bbPress project once BP Rewrites has been merged into BuddyPress core.

A few more steps may be required, at least one : using BP Rewrites to build links inside the Forum component.

## How has this been tested?
Fixing bbPress issues

## Types of changes
Forward compatibility for bbPress

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
