### PR TITLE
Prevents a fatal error when trying to edit a nav too early.

### DIFF
--- a/src/bp-core/classes/class-core-nav-compat.php
+++ b/src/bp-core/classes/class-core-nav-compat.php
@@ -124,4 +124,18 @@ class Core_Nav_Compat {
 			}
 		}
 	}
+
+	/**
+	 * Prevents a fatal error when trying to edit a nav too early.
+	 *
+	 * @since 1.3.1
+	 *
+	 * @param array  $args        The nav item's arguments.
+	 * @param string $slug        The slug of the nav item.
+	 * @param string $parent_slug The slug of the parent nav item (required to edit a child).
+	 * @return null
+	 */
+	public function edit_nav( $args = array(), $slug = '', $parent_slug = '' ) {
+		return null;
+	}
 }


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
When trying to edit a nav too early, the `BP\Rewrites\Core_Nav_Compat` can be used instead of `BP_Core_Nav`. In this case a fatal error occurs as the BP Rewrites compat class do not provide a `BP\Rewrites\Core_Nav_Compat::edit_nav()` method

See: https://wordpress.org/support/topic/getting-more-errors/

## How has this been tested?
Working on a fix for the bug shared by @teeboy4real

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
