### PR TITLE
Add a feature to restrict community area to members

### DIFF
--- a/inc/loader.php
+++ b/inc/loader.php
@@ -29,6 +29,7 @@ function includes( $plugin_dir = '' ) {
 	require $path . 'src/bp-core/bp-core-rewrites.php';
 	require $path . 'src/bp-core/bp-core-catchuri.php';
 	require $path . 'src/bp-core/bp-core-functions.php';
+	require $path . 'src/bp-core/bp-core-caps.php';
 	require $path . 'src/bp-core/bp-core-filters.php';
 
 	// The Members component is always active.

--- a/inc/update.php
+++ b/inc/update.php
@@ -44,8 +44,9 @@ function updater() {
 		// Switch the post type.
 		wp_update_post(
 			array(
-				'ID'        => $directory_page->id,
-				'post_type' => $post_type,
+				'ID'          => $directory_page->id,
+				'post_type'   => $post_type,
+				'post_status' => 'publish',
 			)
 		);
 	}

--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -53,3 +53,87 @@ function bp_remove_page_settings_submenu_page() {
 	remove_submenu_page( get_settings_page(), 'bp-page-settings' );
 }
 add_action( 'bp_admin_init', __NAMESPACE__ . '\bp_remove_page_settings_submenu_page' );
+
+/**
+ * Returns the current visibility of community pages.
+ *
+ * @since ?.0.0
+ *
+ * @return string The current visibility of community pages.
+ */
+function bp_admin_get_community_visibility() {
+	$visibility = 'anyone';
+	$bp_pages   = (array) buddypress()->pages;
+
+	// Remove pages needing to always be visible.
+	unset( $bp_pages['activate'], $bp_pages['register'] );
+
+	if ( count( $bp_pages ) === count( wp_filter_object_list( $bp_pages, array( 'visibility' => 'bp_restricted' ) ) ) ) {
+		$visibility = 'members';
+	}
+
+	return $visibility;
+}
+
+/**
+ * Outputs the community visibility settings.
+ *
+ * @since ?.0.0
+ */
+function bp_admin_setting_callback_community_visibility() {
+	$visibility = bp_admin_get_community_visibility();
+	?>
+
+		<select name="_bp_community_visibility" id="_bp_community_visibility" aria-describedby="_bp_community_visibility_description">
+			<option value="publish" <?php selected( 'anyone', $visibility, true ); ?>><?php esc_html_e( 'Anyone', 'bp-rewrites' ); ?></option>
+			<option value="bp_restricted" <?php selected( 'members', $visibility, true ); ?>><?php esc_html_e( 'Members', 'bp-rewrites' ); ?></option>
+		</select>
+		<p id="_bp_community_visibility_description" class="description"><?php esc_html_e( 'Choose "Members" to restrict your community area to logged in members only. Choose "Anyone" to allow any user to access to your community area.', 'bp-rewrites' ); ?></p>
+
+	<?php
+}
+
+/**
+ * Sanitizes the community visibility option and updates community pages status.
+ *
+ * @since ?.0.0
+ *
+ * @param string $status The post status to use for community pages.
+ * @return string The sanitized community visibility option.
+ */
+function bp_admin_setting_callback_community_update_visibility( $status = 'publish' ) {
+	$visibility = bp_admin_get_community_visibility();
+
+	if ( 'publish' !== $status && 'bp_restricted' !== $status ) {
+		return 'members' === $visibility ? 'bp_restricted' : 'publish';
+	}
+
+	if ( $visibility !== $status ) {
+		foreach ( buddypress()->pages as $key => $page ) {
+			if ( 'register' === $key || 'activate' === $key ) {
+				continue;
+			}
+
+			wp_update_post(
+				array(
+					'ID'          => $page->id,
+					'post_status' => $status,
+				)
+			);
+		}
+	}
+
+	return $status;
+}
+
+/**
+ * Registers the community visibility setting into BuddyPress options.
+ *
+ * @since ?.0.0
+ */
+function bp_register_admin_settings() {
+	// Community visibility.
+	add_settings_field( '_bp_community_visibility', __( 'Community Visibility', 'bp-rewrites' ), __NAMESPACE__ . '\bp_admin_setting_callback_community_visibility', 'buddypress', 'bp_main', array( 'label_for' => '_bp_community_visibility' ) );
+	register_setting( 'buddypress', '_bp_community_visibility', __NAMESPACE__ . '\bp_admin_setting_callback_community_update_visibility' );
+}
+add_action( 'bp_register_admin_settings', __NAMESPACE__ . '\bp_register_admin_settings', 100 );

--- a/src/bp-core/bp-core-caps.php
+++ b/src/bp-core/bp-core-caps.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * BuddyPress Capabilities.
+ *
+ * @package buddypress\bp-core
+ * @since 1.6.0
+ */
+
+namespace BP\Rewrites;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Map community caps to built in WordPress caps.
+ *
+ * @since ?.0.0
+ *
+ * @see WP_User::has_cap() for description of the arguments passed to the
+ *      'map_meta_cap' filter.
+ *       args.
+ *
+ * @param array  $caps    See {@link WP_User::has_cap()}.
+ * @param string $cap     See {@link WP_User::has_cap()}.
+ * @param int    $user_id See {@link WP_User::has_cap()}.
+ * @param mixed  $args    See {@link WP_User::has_cap()}.
+ * @return array Actual capabilities for meta capability. See {@link WP_User::has_cap()}.
+ */
+function bp_map_meta_caps( $caps, $cap, $user_id, $args ) {
+	if ( 'bp_read' === $cap ) {
+		$capability_args = (array) $args;
+		$capability_args = reset( $capability_args );
+
+		// Resticted to Site's subscribers by default.
+		$caps = array( 'read' );
+		if ( isset( $capability_args['bp_component_visibility'] ) && 'publish' === $capability_args['bp_component_visibility'] ) {
+			// Allowed for everyone.
+			$caps = array( 'exist' );
+		}
+	}
+
+	return $caps;
+}
+add_filter( 'bp_map_meta_caps', __NAMESPACE__ . '\bp_map_meta_caps', 1, 4 );

--- a/src/bp-templates/assets/utils/restricted-message.php
+++ b/src/bp-templates/assets/utils/restricted-message.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Message to inform the community is restricted to members.
+ *
+ * @package \bp-rewrites\src\bp-templates\assets\utils
+ *
+ * @since 1.5.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<!-- wp:paragraph -->
+<p><?php esc_html_e( 'This community area is restricted to members.', 'bp-rewrites' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:bp/login-form {"forgotPwdLink":true} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
Adds a new BuddyPress option to make the community only visible to its members.

## How has this been tested?
Developing it.

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
