### PR TITLE
Use newly introduced `bp_core_get_directory_pages_stati` filter to include possible restricted BP Pages

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -655,26 +655,18 @@ function is_bp_doing_ajax() {
 }
 
 /**
- * Edits the query used in `bp_core_get_directory_pages()` so that it includes the `bp_restricted` post status.
+ * Adds the `bp_restricted` status to the allowed BP Directory Pages stati.
  *
  * @since 1.5.0
  *
- * @param string $query The MySQL query to be performed by the `$wpdb` API.
- * @return string The MySQL query to be performed by the `$wpdb` API.
+ * @param array $stati The allowed BP Directory Pages stati.
+ * @return array The allowed BP Directory Pages stati.
  */
-function get_directory_pages( $query ) {
-	if ( 0 === strpos( $query, 'SELECT ID, post_name, post_parent, post_title' ) ) {
-		$page_ids_sql = implode( ',', wp_parse_id_list( bp_core_get_directory_page_ids() ) );
-		$needle       = "WHERE ID IN ({$page_ids_sql}) AND post_status = 'publish'";
-
-		if ( false !== strpos( $query, $needle ) ) {
-			$query = str_replace( "post_status = 'publish'", "post_status IN ( 'publish', 'bp_restricted' )", $query );
-		}
-	}
-
-	return $query;
+function get_directory_pages_stati( $stati = array() ) {
+	$stati[] = 'bp_restricted';
+	return $stati;
 }
-add_filter( 'query', __NAMESPACE__ . '\get_directory_pages' );
+add_filter( 'bp_core_get_directory_pages_stati', __NAMESPACE__ . '\get_directory_pages_stati' );
 
 /**
  * Get Templates directory.


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
Now See https://github.com/buddypress/buddypress/pull/40 has been committed let's avoid filtering `query` and use the newly introduded filter instead to include potential BP Pages restricted to members.

## How has this been tested?
Developping it.

## Types of changes
Improvement

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
