### PR TITLE
Check BP is 11.0+ before supporting the community visibility feature

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -458,14 +458,17 @@ function bp_core_register_post_types() {
 			)
 		);
 
-		register_post_status(
-			'bp_restricted',
-			array(
-				'label'    => _x( 'Restricted to members', 'post status', 'bp-rewrites' ),
-				'public'   => false,
-				'internal' => true,
-			)
-		);
+		// Check BuddyPress is >= 11.0.
+		if ( function_exists( 'bp_core_get_directory_pages_stati' ) ) {
+			register_post_status(
+				'bp_restricted',
+				array(
+					'label'    => _x( 'Restricted to members', 'post status', 'bp-rewrites' ),
+					'public'   => false,
+					'internal' => true,
+				)
+			);
+		}
 	}
 }
 add_action( 'bp_core_register_post_types', __NAMESPACE__ . '\bp_core_register_post_types' );

--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -132,6 +132,11 @@ function bp_admin_setting_callback_community_update_visibility( $status = 'publi
  * @since ?.0.0
  */
 function bp_register_admin_settings() {
+	// Check BuddyPress is >= 11.0.
+	if ( ! function_exists( 'bp_core_get_directory_pages_stati' ) ) {
+		return;
+	}
+
 	// Community visibility.
 	add_settings_field( '_bp_community_visibility', __( 'Community Visibility', 'bp-rewrites' ), __NAMESPACE__ . '\bp_admin_setting_callback_community_visibility', 'buddypress', 'bp_main', array( 'label_for' => '_bp_community_visibility' ) );
 	register_setting( 'buddypress', '_bp_community_visibility', __NAMESPACE__ . '\bp_admin_setting_callback_community_update_visibility' );


### PR DESCRIPTION
<!-- All WordPress projects are licensed under the GPLv2+, and all contributions to BP Rewrites will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license. For more information, see: https://github.com/buddypress/bp-rewrites/blob/trunk/LICENSE.md -->

## Description
Make sure the BP function to get allowed stati is available before creating the custom post status and BP option to restrict BP pages to members.

## How has this been tested?
Developing it

## Screenshots <!-- if applicable -->

## Types of changes
 Bug fix (when BP < 11.0)

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
