### PR TITLE
Use an option instead of a post status to set community visibility

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -367,12 +367,7 @@ function bp_component_pre_query( $return = null, \WP_Query $query = null ) {
 	$queried_object = $query->get_queried_object();
 
 	if ( $queried_object instanceof \WP_Post && 'buddypress' === get_post_type( $queried_object ) ) {
-		$capability_args = array(
-			'bp_page_id'              => $queried_object->ID,
-			'bp_component_visibility' => get_post_status( $queried_object ),
-		);
-
-		if ( ! bp_current_user_can( 'bp_read', $capability_args ) ) {
+		if ( ! bp_current_user_can( 'bp_read' ) ) {
 			$bp                    = buddypress();
 			$bp->current_component = 'core';
 
@@ -457,18 +452,6 @@ function bp_core_register_post_types() {
 				'delete_with_user'    => false,
 			)
 		);
-
-		// Check BuddyPress is >= 11.0.
-		if ( function_exists( 'bp_core_get_directory_pages_stati' ) ) {
-			register_post_status(
-				'bp_restricted',
-				array(
-					'label'    => _x( 'Restricted to members', 'post status', 'bp-rewrites' ),
-					'public'   => false,
-					'internal' => true,
-				)
-			);
-		}
 	}
 }
 add_action( 'bp_core_register_post_types', __NAMESPACE__ . '\bp_core_register_post_types' );
@@ -555,7 +538,6 @@ function get_components_custom_slugs( $pages = null ) {
 	if ( $pages ) {
 		foreach ( $pages as $component_id => $page ) {
 			$pages->{$component_id}->custom_slugs = get_post_meta( $page->id, '_bp_component_slugs', true );
-			$pages->{$component_id}->visibility   = get_post_status( $page->id );
 		}
 	}
 

--- a/src/bp-core/bp-core-caps.php
+++ b/src/bp-core/bp-core-caps.php
@@ -30,15 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function bp_map_meta_caps( $caps, $cap, $user_id, $args ) {
 	if ( 'bp_read' === $cap ) {
-		$capability_args = (array) $args;
-		$capability_args = reset( $capability_args );
-
-		// Resticted to Site's subscribers by default.
-		$caps = array( 'read' );
-		if ( isset( $capability_args['bp_component_visibility'] ) && 'publish' === $capability_args['bp_component_visibility'] ) {
-			// Allowed for everyone.
-			$caps = array( 'exist' );
-		}
+		$caps = 'members' === bp_get_community_visibility() ? array( 'read' ) : array( 'exist' );
 	}
 
 	return $caps;

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -172,3 +172,24 @@ function bp_is_directory_homepage( $component = '' ) {
 
 	return $is_directory_homepage;
 }
+
+/**
+ * Get the community area visibility.
+ *
+ * @since ?.0.0
+ *
+ * @param string $default Optional. Fallback value if not found in the database.
+ *                        Default: 'anyone'.
+ * @return string The visibility of the community area. Possible values are `anyone` or `members`.
+ */
+function bp_get_community_visibility( $default = 'anyone' ) {
+
+	/**
+	 * Filters the current community area visibility.
+	 *
+	 * @since ?.0.0
+	 *
+	 * @param string $value The current community area visibility.
+	 */
+	return apply_filters( 'bp_get_community_visibility', bp_get_option( '_bp_community_visibility', $default ) );
+}


### PR DESCRIPTION
## Description
Using a post status different than `publish` fails into the WP Ajax context. I figured it out noticing group links and member links inside their corresponding loops are not rewritten by the plugin. In case I'm too short to understand why it fails in Ajax before BuddyPress 11.0.0, this PR is a back up plan.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
