### PR TITLE
Prepare version 1.6.0 of the plugin

### DIFF
--- a/class-bp-rewrites.php
+++ b/class-bp-rewrites.php
@@ -11,7 +11,7 @@
  * Plugin Name:       BP Rewrites
  * Plugin URI:        https://github.com/buddypress/bp-rewrites
  * Description:       BuddyPress Rewrites development plugin.
- * Version:           1.5.0
+ * Version:           1.6.0
  * Author:            The BuddyPress Community
  * Author URI:        https://buddypress.org
  * License:           GPL-2.0+
@@ -67,21 +67,25 @@ final class BP_Rewrites {
 	 *
 	 * @since 1.0.0
 	 */
-	public static function is_buddypress_active() {
-		$bp_plugin_basename   = 'buddypress/bp-loader.php';
-		$is_buddypress_active = false;
-		$sitewide_plugins     = (array) get_site_option( 'active_sitewide_plugins', array() );
+	public static function is_buddypress_supported() {
+		$bp_plugin_basename      = 'buddypress/bp-loader.php';
+		$is_buddypress_supported = false;
+		$sitewide_plugins        = (array) get_site_option( 'active_sitewide_plugins', array() );
 
 		if ( $sitewide_plugins ) {
-			$is_buddypress_active = isset( $sitewide_plugins[ $bp_plugin_basename ] );
+			$is_buddypress_supported = isset( $sitewide_plugins[ $bp_plugin_basename ] );
 		}
 
-		if ( ! $is_buddypress_active ) {
-			$plugins              = (array) get_option( 'active_plugins', array() );
-			$is_buddypress_active = in_array( $bp_plugin_basename, $plugins, true );
+		if ( ! $is_buddypress_supported ) {
+			$plugins                 = (array) get_option( 'active_plugins', array() );
+			$is_buddypress_supported = in_array( $bp_plugin_basename, $plugins, true );
 		}
 
-		return $is_buddypress_active;
+		if ( $is_buddypress_supported ) {
+			$is_buddypress_supported = version_compare( bp_get_version(), '12.0.0-alpha', '<' );
+		}
+
+		return $is_buddypress_supported;
 	}
 
 	/**
@@ -102,7 +106,7 @@ final class BP_Rewrites {
 	 * @since 1.0.0
 	 */
 	public static function admin_notice() {
-		if ( self::is_buddypress_active() ) {
+		if ( self::is_buddypress_supported() ) {
 			return false;
 		}
 
@@ -112,8 +116,9 @@ final class BP_Rewrites {
 			'<div class="notice notice-error is-dismissible"><p>%s</p></div>',
 			sprintf(
 				/* translators: 1. is the link to the BuddyPress plugin on the WordPress.org plugin directory. */
-				esc_html__( 'BP Rewrites requires the %1$s plugin to be active. Please deactivate BP Rewrites, activate %1$s and only then, reactivate BP Rewrites.', 'bp-rewrites' ),
-				$bp_plugin_link // phpcs:ignore
+				esc_html__( 'BP Rewrites requires the %1$s plugin to be active and its version must be %2$s. Please deactivate BP Rewrites, activate %1$s %2$s and only then, reactivate BP Rewrites.', 'bp-rewrites' ),
+				$bp_plugin_link, // phpcs:ignore
+				'<b>< 12.0.0</b>' // phpcs:ignore
 			)
 		);
 	}
@@ -125,7 +130,7 @@ final class BP_Rewrites {
 	 */
 	public static function start() {
 		// This plugin is only usable with BuddyPress.
-		if ( ! self::is_buddypress_active() ) {
+		if ( ! self::is_buddypress_supported() ) {
 			return false;
 		}
 

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,11 @@
     "format": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf --standard=WordPress",
     "lint:php": "@php ./vendor/bin/parallel-lint --exclude .git --exclude node_modules --exclude vendor .",
     "phpcompat": "@php ./vendor/bin/phpcs -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 5.6- inc src class-bp-rewrites.php"
+  },
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/inc/globals.php
+++ b/inc/globals.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function globals() {
 	$bpr = bp_rewrites();
 
-	$bpr->version = '1.5.0';
+	$bpr->version = '1.6.0';
 
 	// Path.
 	$plugin_dir = plugin_dir_path( dirname( __FILE__ ) );

--- a/inc/update.php
+++ b/inc/update.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0.0
  */
 function updater() {
-	if ( ! BP_Rewrites::is_buddypress_active() ) {
+	if ( ! BP_Rewrites::is_buddypress_supported() ) {
 		return false;
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "bp-rewrites",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bp-rewrites",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "BuddyPress Rewrites development plugin",
   "scripts": {
     "pot": "wp i18n make-pot . languages/bp-rewrites.pot --exclude='.github,vendor' --headers='{\"Project-Id-Version\": \"BP Rewrites\", \"Report-Msgid-Bugs-To\": \"https://github.com/buddypress/bp-rewrites/issues\", \"Last-Translator\": \"JOHN JAMES JACOBY <jjj@buddypress.org>\", \"Language-Team\": \"ENGLISH <jjj@buddypress.org>\"}'"

--- a/src/bp-groups/classes/class-bp-group-extension.php
+++ b/src/bp-groups/classes/class-bp-group-extension.php
@@ -1558,7 +1558,7 @@ if ( ! class_exists( 'BP_Group_Extension', false ) ) :
 			$properties = $this->get_legacy_property_list();
 
 			// By-reference variable for convenience.
-			$lpc =& $this->legacy_properties_converted;
+			$lpc =& $this->legacy_properties_converted; // phpcs:ignore
 
 			foreach ( $properties as $property ) {
 
@@ -1635,7 +1635,7 @@ if ( ! class_exists( 'BP_Group_Extension', false ) ) :
 
 			$properties = $this->get_legacy_property_list();
 			$params     = $this->params;
-			$lp         =& $this->legacy_properties;
+			$lp         =& $this->legacy_properties; // phpcs:ignore
 
 			foreach ( $properties as $property ) {
 				switch ( $property ) {


### PR DESCRIPTION
## Description
Adds a BP version check to make sure plugin's code is only run if version is lower than 12.0.0

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
