### PR TITLE
`Core_Nav_Compat`: Only send notices in right contexts

### DIFF
--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -53,37 +53,8 @@ function _is_bp_was_called_too_early_exceptions( $trace = '' ) {
  * @return mixed            The BuddyPress global value set using the BP Legacy URL parser.
  */
 function _was_called_too_early( $function, $bp_global ) {
-	$retval      = null;
-	$request_uri = '';
-	if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-		$request_uri = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
-	}
-
-	// Into WP Admin context BP Front end globals are not set.
-	$request  = wp_parse_url( $request_uri, PHP_URL_PATH );
-	$is_admin = ( false !== strpos( $request, '/wp-admin' ) || is_admin() ) && ! wp_doing_ajax();
-
-	// Into the following contexts BP Front end globals are also not set.
-	$wp_specific_paths   = array( '/wp-login.php', '/wp-comments-post.php', '/wp-signup.php', '/wp-activate.php', '/wp-trackback.php' );
-	$is_wp_specific_path = false;
-
-	foreach ( $wp_specific_paths as $wp_specific_path ) {
-		if ( false === strpos( $request, $wp_specific_path ) ) {
-			continue;
-		}
-
-		$is_wp_specific_path = true;
-	}
-
-	// The BP REST API needs more work.
-	$is_rest = false !== strpos( $request, '/' . rest_get_url_prefix() ) || ( defined( 'REST_REQUEST' ) && REST_REQUEST );
-
-	// The XML RPC API needs more work.
-	$is_xmlrpc = defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST;
-
-	// `bp_parse_query` is not fired in WP Admin.
-	if ( did_action( 'bp_parse_query' ) || $is_admin || $is_wp_specific_path || $is_rest || $is_xmlrpc || wp_doing_cron() ) {
-		return $retval;
+	if ( did_action( 'bp_parse_query' ) || ! needs_query_check() ) {
+		return null;
 	}
 
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {

--- a/src/bp-core/classes/class-core-nav-compat.php
+++ b/src/bp-core/classes/class-core-nav-compat.php
@@ -28,7 +28,10 @@ class Core_Nav_Compat {
 	 * @since 1.0.0
 	 */
 	public function __construct() {
-		add_action( 'bp_parse_query', array( $this, 'doing_it_wrong' ), 11 );
+		if ( needs_query_check() ) {
+			add_action( 'bp_parse_query', array( $this, 'doing_it_wrong' ), 11 );
+		}
+
 		add_action( 'bp_setup_nav', array( $this, 'compat' ), 1000 );
 	}
 


### PR DESCRIPTION
Fixes #50

## Description
There's no need to use `Core_Nav_Compat::doing_it_wrong()` for contexts where BuddyPress shouldn't play.

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code is back compatible with PHP 5.6. <!-- Check code: `composer phpcompat` --> 
- [x] My code follows the WordPress code style. <!-- Check code: `composer do:wpcs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
